### PR TITLE
Moved chunk splitting to designer build script. Added reference to vendor script in index.html.

### DIFF
--- a/src/themes/designer/assets/index.html
+++ b/src/themes/designer/assets/index.html
@@ -8,10 +8,11 @@
 
     <title>API Management</title>
 
-    <link href="/editors/styles/paperbits.css" rel="stylesheet" type="text/css">
-    <script src="/editors/scripts/paperbits.js" type="text/javascript"></script>
-
     <link rel="shortcut icon" type="image/png" href="favicon.png" />
+    <link href="/editors/styles/paperbits.css" rel="stylesheet" type="text/css">
+
+    <script src="/vendor.js" type="text/javascript"></script>
+    <script src="/editors/scripts/paperbits.js" type="text/javascript"></script>
 </head>
 
 <body>

--- a/webpack.build.js
+++ b/webpack.build.js
@@ -18,16 +18,7 @@ module.exports = merge(designerConfig, {
                     }
                 }
             })
-        ],
-        splitChunks: {
-            cacheGroups: {
-                vendor: {
-                    test: /[\\/]node_modules[\\/]/,
-                    name: "vendor",
-                    chunks: "initial"
-                }
-            }
-        }
+        ]
     },
     plugins: [
         new CleanWebpackPlugin(),

--- a/webpack.designer.js
+++ b/webpack.designer.js
@@ -14,6 +14,17 @@ module.exports = {
         "scripts/theme": ["./src/startup.runtime.ts"],
         "styles/theme": [`./src/themes/${websiteTheme}/styles/styles.design.scss`]
     },
+    optimization: {
+        splitChunks: {
+            cacheGroups: {
+                vendor: {
+                    test: /[\\/]node_modules[\\/]/,
+                    name: "vendor",
+                    chunks: "initial"
+                }
+            }
+        }
+    },
     output: {
         filename: "./[name].js",
         path: path.resolve(__dirname, "./dist/designer")


### PR DESCRIPTION
Large script files makes debugging painful since it takes a few seconds to load them into browser debugger every time. So we enable chunk splitting not only for production but for development mode as well.