### PR TITLE
Added details page selectors for list widget editors.

### DIFF
--- a/scripts/generate.bat
+++ b/scripts/generate.bat
@@ -4,7 +4,7 @@ set management_endpoint="< service name >.management.azure-api.net"
 set access_token="SharedAccessSignature ..."
 set storage_connection_string="DefaultEndpointsProtocol=..."
 set data_file="./data.json"
-set media_folder="./content"
+set media_folder="./media"
 
 node ./generate %management_endpoint% %access_token% %data_file%
 node ./upload %storage_connection_string% %media_folder%

--- a/src/apim.runtime.module.ts
+++ b/src/apim.runtime.module.ts
@@ -7,6 +7,7 @@ import "./bindingHandlers/markdown";
 import "./bindingHandlers/barChart";
 import "./bindingHandlers/mapChart";
 import "./bindingHandlers/minMaxAvgChart";
+import "./bindingHandlers/acceptChange";
 import "@paperbits/core/ko/bindingHandlers/bindingHandlers.component";
 import "@paperbits/core/ko/bindingHandlers/bindingHandlers.focus";
 import "@paperbits/core/ko/bindingHandlers/bindingHandlers.activate";

--- a/src/bindingHandlers/acceptChange.ts
+++ b/src/bindingHandlers/acceptChange.ts
@@ -1,0 +1,17 @@
+import * as ko from "knockout";
+
+ko.extenders.acceptChange = (target, condition) => {
+    const result = ko.pureComputed({
+        read: target,
+        write: (newValue) => {
+            if (!ko.unwrap(condition)) {
+                return;
+            }
+            target(newValue);
+        }
+    });
+
+    result(target());
+
+    return result;
+};

--- a/src/components/apis/list-of-apis/ko/listOfApis.html
+++ b/src/components/apis/list-of-apis/ko/listOfApis.html
@@ -1,11 +1,11 @@
-<!-- ko if: itemStyleView() === 'list' -->
-<api-list></api-list>
+<!-- ko if: layout() === 'list' -->
+<api-list data-bind="attr: { params: runtimeConfig }"></api-list>
 <!-- /ko -->
 
-<!-- ko if: itemStyleView() === 'dropdown' -->
-<api-list-dropdown></api-list-dropdown>
+<!-- ko if: layout() === 'dropdown' -->
+<api-list-dropdown data-bind="attr: { params: runtimeConfig }"></api-list-dropdown>
 <!-- /ko -->
 
-<!-- ko if: itemStyleView() === 'tiles' -->
-<api-list-tiles></api-list-tiles>
+<!-- ko if: layout() === 'tiles' -->
+<api-list-tiles data-bind="attr: { params: runtimeConfig }"></api-list-tiles>
 <!-- /ko -->

--- a/src/components/apis/list-of-apis/ko/listOfApisEditor.html
+++ b/src/components/apis/list-of-apis/ko/listOfApisEditor.html
@@ -1,13 +1,24 @@
 <fieldset class="form flex-item flex-item-grow" data-bind="scrollable: {}">
-    <b>Coming soon</b>
-    <p>
-        An editor for this widget is not yet ready.<br />
-    </p>
-    <!-- <div class="form-group">
-        <label for="item-style" class="form-label">
-            Item style
-            <button class="btn btn-info" type="button" data-bind="infoMessageToggle: 'Api item control view.'"></button>
+    <div class="form-group">
+        <label for="allowSelection" class="form-label">
+            <input type="checkbox" id="allowSelection" name="allowSelection" data-bind="checked: allowSelection" />
+            Allow selection
         </label>
-        <select id="item-style" class="form-control" data-bind="options: itemStyles, value: itemStyle, optionsText: 'name', optionsValue: 'styleValue'"></select>
-    </div> -->
+    </div>
+
+    <div class="form-group">
+        <label class="form-label">
+            Link to API details page
+            <button class="btn btn-info" type="button" title="Help"
+                data-bind="tooltipToggle: 'A link to be navigated on click.'"></button>
+        </label>
+        <div class="input-group">
+            <a href="#" class="form-control"
+                data-bind="text: hyperlinkTitle, balloon: { component: { name: 'hyperlink-selector', params: { hyperlink: $component.hyperlink, onChange: $component.onHyperlinkChange } } }">
+            </a>
+            <div class="input-group-addon">
+                <i class="paperbits-icon paperbits-link-69-2"></i>
+            </div>
+        </div>
+    </div>
 </fieldset>

--- a/src/components/apis/list-of-apis/ko/listOfApisEditor.ts
+++ b/src/components/apis/list-of-apis/ko/listOfApisEditor.ts
@@ -1,8 +1,9 @@
 import * as ko from "knockout";
 import template from "./listOfApisEditor.html";
-import { StyleService } from "@paperbits/styles";
 import { Component, OnMounted, Param, Event } from "@paperbits/common/ko/decorators";
+import { HyperlinkModel } from "@paperbits/common/permalinks";
 import { ListOfApisModel } from "../listOfApisModel";
+
 
 @Component({
     selector: "list-of-apis-editor",
@@ -10,15 +11,26 @@ import { ListOfApisModel } from "../listOfApisModel";
     injectable: "listOfApisEditor"
 })
 export class ListOfApisEditor {
-    public itemStyles: ko.ObservableArray<any>;
-    public itemStyle: ko.Observable<string>;
+    public readonly itemStyles: ko.ObservableArray<any>;
+    public readonly itemStyle: ko.Observable<string>;
+    public readonly allowSelection: ko.Observable<boolean>;
+    public readonly hyperlink: ko.Observable<HyperlinkModel>;
+    public readonly hyperlinkTitle: ko.Computed<string>;
 
-    constructor(private readonly styleService: StyleService) {
+    constructor() {
+        this.allowSelection = ko.observable(false);
+        this.hyperlink = ko.observable();
+        this.hyperlinkTitle = ko.computed<string>(
+            () => this.hyperlink()
+                ? this.hyperlink().title
+                : "Add a link...");
+
         this.itemStyles = ko.observableArray<any>([
-            {name: "List", styleValue: "list"},
-            {name: "Tiles", styleValue: "tiles"},
-            {name: "Dropdown", styleValue: "dropdown"}
+            { name: "List", styleValue: "list" },
+            { name: "Tiles", styleValue: "tiles" },
+            { name: "Dropdown", styleValue: "dropdown" }
         ]);
+
         this.itemStyle = ko.observable<any>();
     }
 
@@ -30,12 +42,20 @@ export class ListOfApisEditor {
 
     @OnMounted()
     public async initialize(): Promise<void> {
-        this.itemStyle(this.model.itemStyleView || "");
-        this.itemStyle.subscribe(this.applyChanges);
+        this.allowSelection(this.model.allowSelection);
+        this.hyperlink(this.model.detailsPageHyperlink);
+
+        this.allowSelection.subscribe(this.applyChanges);
     }
 
     private applyChanges(): void {
-        this.model.itemStyleView = this.itemStyle();
+        this.model.allowSelection = this.allowSelection();
+        this.model.detailsPageHyperlink = this.hyperlink();
         this.onChange(this.model);
+    }
+
+    public onHyperlinkChange(hyperlink: HyperlinkModel): void {
+        this.hyperlink(hyperlink);
+        this.applyChanges();
     }
 }

--- a/src/components/apis/list-of-apis/ko/listOfApisViewModel.ts
+++ b/src/components/apis/list-of-apis/ko/listOfApisViewModel.ts
@@ -7,9 +7,11 @@ import { Component } from "@paperbits/common/ko/decorators";
     template: template
 })
 export class ListOfApisViewModel {
-    public itemStyleView: ko.Observable<string>;
+    public readonly layout: ko.Observable<string>;
+    public readonly runtimeConfig: ko.Observable<string>;
 
     constructor() {        
-        this.itemStyleView = ko.observable();
+        this.layout = ko.observable();
+        this.runtimeConfig = ko.observable();
     }
 }

--- a/src/components/apis/list-of-apis/ko/listOfApisViewModelBinder.ts
+++ b/src/components/apis/list-of-apis/ko/listOfApisViewModelBinder.ts
@@ -7,21 +7,28 @@ import { EventManager } from "@paperbits/common/events";
 
 export class ListOfApisViewModelBinder implements ViewModelBinder<ListOfApisModel, ListOfApisViewModel> {
 
-    constructor(private readonly eventManager: EventManager) {}
-    
+    constructor(private readonly eventManager: EventManager) { }
+
     public async modelToViewModel(model: ListOfApisModel, viewModel?: ListOfApisViewModel, bindingContext?: Bag<any>): Promise<ListOfApisViewModel> {
         if (!viewModel) {
             viewModel = new ListOfApisViewModel();
         }
 
-        viewModel.itemStyleView(model.itemStyleView);
+        viewModel.layout(model.layout);
+
+        viewModel.runtimeConfig(JSON.stringify({
+            allowSelection: model.allowSelection,
+            detailsPageUrl: model.detailsPageHyperlink
+                ? model.detailsPageHyperlink.href
+                : undefined
+        }));
 
         viewModel["widgetBinding"] = {
             displayName: "List of APIs",
             model: model,
             editor: "list-of-apis-editor",
             applyChanges: async (updatedModel: ListOfApisModel) => {
-                this.modelToViewModel(updatedModel, viewModel, bindingContext);
+                await this.modelToViewModel(updatedModel, viewModel, bindingContext);
                 this.eventManager.dispatchEvent("onContentUpdate");
             }
         };

--- a/src/components/apis/list-of-apis/ko/runtime/api-list-dropdown.ts
+++ b/src/components/apis/list-of-apis/ko/runtime/api-list-dropdown.ts
@@ -1,7 +1,7 @@
 import * as ko from "knockout";
 import * as Constants from "../../../../../constants";
 import template from "./api-list-dropdown.html";
-import { Component, RuntimeComponent, OnMounted } from "@paperbits/common/ko/decorators";
+import { Component, RuntimeComponent, OnMounted, Param } from "@paperbits/common/ko/decorators";
 import { RouteHelper } from "./../../../../../routing/routeHelper";
 import { Api } from "../../../../../models/api";
 import { ApiService } from "../../../../../services/apiService";
@@ -32,8 +32,10 @@ export class ApiListDropdown {
         private readonly apiService: ApiService,
         private readonly routeHelper: RouteHelper
     ) {
+        this.detailsPageUrl = ko.observable();
+        this.allowSelection = ko.observable(false);
         this.working = ko.observable();
-        this.selectedApiName = ko.observable();
+        this.selectedApiName = ko.observable().extend(<any>{ acceptChange: this.allowSelection });
         this.pattern = ko.observable();
         this.page = ko.observable(1);
         this.hasPrevPage = ko.observable();
@@ -47,6 +49,12 @@ export class ApiListDropdown {
             return api ? api.displayName : "Select API";
         });
     }
+
+    @Param()
+    public allowSelection: ko.Observable<boolean>;
+
+    @Param()
+    public detailsPageUrl: ko.Observable<string>;
 
     @OnMounted()
     public async initialize(): Promise<void> {
@@ -113,6 +121,6 @@ export class ApiListDropdown {
     }
 
     public getReferenceUrl(api: Api): string {
-        return this.routeHelper.getApiReferenceUrl(api.name);
+        return this.routeHelper.getApiReferenceUrl(api.name, this.detailsPageUrl());
     }
 }

--- a/src/components/apis/list-of-apis/ko/runtime/api-list-tiles.ts
+++ b/src/components/apis/list-of-apis/ko/runtime/api-list-tiles.ts
@@ -1,7 +1,7 @@
 import * as ko from "knockout";
 import * as Constants from "../../../../../constants";
 import template from "./api-list-tiles.html";
-import { Component, RuntimeComponent, OnMounted } from "@paperbits/common/ko/decorators";
+import { Component, RuntimeComponent, OnMounted, Param } from "@paperbits/common/ko/decorators";
 import { ApiService } from "../../../../../services/apiService";
 import { Api } from "../../../../../models/api";
 import { TagGroup } from "../../../../../models/tagGroup";
@@ -9,7 +9,9 @@ import { SearchQuery } from "../../../../../contracts/searchQuery";
 import { RouteHelper } from "../../../../../routing/routeHelper";
 
 
-@RuntimeComponent({ selector: "api-list-tiles" })
+@RuntimeComponent({
+    selector: "api-list-tiles"
+})
 @Component({
     selector: "api-list-tiles",
     template: template,
@@ -31,9 +33,11 @@ export class ApiListTiles {
         private readonly apiService: ApiService,
         private readonly routeHelper: RouteHelper
     ) {
+        this.detailsPageUrl = ko.observable();
+        this.allowSelection = ko.observable(false);
         this.apis = ko.observableArray([]);
         this.working = ko.observable();
-        this.selectedApiName = ko.observable();
+        this.selectedApiName = ko.observable().extend(<any>{ acceptChange: this.allowSelection });
         this.pattern = ko.observable();
         this.page = ko.observable(1);
         this.hasPrevPage = ko.observable();
@@ -42,6 +46,12 @@ export class ApiListTiles {
         this.apiGroups = ko.observableArray();
         this.groupByTag = ko.observable(false);
     }
+
+    @Param()
+    public allowSelection: ko.Observable<boolean>;
+
+    @Param()
+    public detailsPageUrl: ko.Observable<string>;
 
     @OnMounted()
     public async initialize(): Promise<void> {
@@ -118,6 +128,6 @@ export class ApiListTiles {
     }
 
     public getReferenceUrl(api: Api): string {
-        return this.routeHelper.getApiReferenceUrl(api.name);
+        return this.routeHelper.getApiReferenceUrl(api.name, this.detailsPageUrl());
     }
 }

--- a/src/components/apis/list-of-apis/ko/runtime/api-list.ts
+++ b/src/components/apis/list-of-apis/ko/runtime/api-list.ts
@@ -1,7 +1,7 @@
 import * as ko from "knockout";
 import * as Constants from "../../../../../constants";
 import template from "./api-list.html";
-import { Component, RuntimeComponent, OnMounted } from "@paperbits/common/ko/decorators";
+import { Component, RuntimeComponent, OnMounted, Param } from "@paperbits/common/ko/decorators";
 import { Api } from "../../../../../models/api";
 import { ApiService } from "../../../../../services/apiService";
 import { TagGroup } from "../../../../../models/tagGroup";
@@ -30,6 +30,8 @@ export class ApiList {
         private readonly apiService: ApiService,
         private readonly routeHelper: RouteHelper
     ) {
+        this.detailsPageUrl = ko.observable();
+        this.allowSelection = ko.observable(false);
         this.apis = ko.observableArray([]);
         this.working = ko.observable();
         this.pattern = ko.observable();
@@ -40,6 +42,12 @@ export class ApiList {
         this.apiGroups = ko.observableArray();
         this.groupByTag = ko.observable(false);
     }
+
+    @Param()
+    public allowSelection: ko.Observable<boolean>;
+
+    @Param()
+    public detailsPageUrl: ko.Observable<string>;
 
     @OnMounted()
     public async initialize(): Promise<void> {
@@ -98,7 +106,7 @@ export class ApiList {
     }
 
     public getReferenceUrl(api: Api): string {
-        return this.routeHelper.getApiReferenceUrl(api.name);
+        return this.routeHelper.getApiReferenceUrl(api.name, this.detailsPageUrl());
     }
 
     public prevPage(): void {

--- a/src/components/apis/list-of-apis/listOfApisContract.ts
+++ b/src/components/apis/list-of-apis/listOfApisContract.ts
@@ -1,5 +1,23 @@
 import { Contract } from "@paperbits/common";
+import { HyperlinkContract } from "@paperbits/common/editing";
 
+
+/**
+ * API list widget contract.
+ */
 export interface ListOfApisContract extends Contract {
+    /**
+     * API list layout.
+     */
     itemStyleView?: string;
+
+    /**
+     * Indicated that an APIs can be selected.
+     */
+    allowSelection: boolean;
+
+    /**
+     * Link to a page that contains API details.
+     */
+    detailsPageHyperlink?: HyperlinkContract;
  }

--- a/src/components/apis/list-of-apis/listOfApisModel.ts
+++ b/src/components/apis/list-of-apis/listOfApisModel.ts
@@ -1,7 +1,22 @@
-export class ListOfApisModel {
-    public itemStyleView?: string;
+import { HyperlinkModel } from "@paperbits/common/permalinks";
 
-    constructor(itemStyleView?: string) {
-        this.itemStyleView = itemStyleView;
+export class ListOfApisModel {
+    /**
+     * List layout.
+     */
+    public layout?: string;
+
+    /**
+     * Indicated that an operations can be selected.
+     */
+    public allowSelection: boolean;
+
+    /**
+     * Link to a page that contains operation details.
+     */
+    public detailsPageHyperlink: HyperlinkModel;
+
+    constructor(layout?: string) {
+        this.layout = layout;
     }
 }

--- a/src/components/apis/list-of-apis/listOfApisModelBinder.ts
+++ b/src/components/apis/list-of-apis/listOfApisModelBinder.ts
@@ -2,16 +2,26 @@ import { Contract } from "@paperbits/common";
 import { IModelBinder } from "@paperbits/common/editing";
 import { ListOfApisModel } from "./listOfApisModel";
 import { ListOfApisContract } from "./listOfApisContract";
+import { IPermalinkResolver } from "@paperbits/common/permalinks";
 
 
 export class ListOfApisModelBinder implements IModelBinder<ListOfApisModel> {
+    constructor(private readonly permalinkResolver: IPermalinkResolver) { }
+    
     public canHandleModel(model: Object): boolean {
         return model instanceof ListOfApisModel;
     }
 
     public async contractToModel(contract: ListOfApisContract): Promise<ListOfApisModel> {
         const model = new ListOfApisModel();
-        model.itemStyleView = contract.itemStyleView;
+        
+        model.layout = contract.itemStyleView;
+        model.allowSelection = contract.allowSelection;
+
+        if (contract.detailsPageHyperlink) {
+            model.detailsPageHyperlink = await this.permalinkResolver.getHyperlinkFromConfig(contract.detailsPageHyperlink);
+        }
+
         return model;
     }
 
@@ -22,7 +32,14 @@ export class ListOfApisModelBinder implements IModelBinder<ListOfApisModel> {
     public modelToContract(model: ListOfApisModel): Contract {
         const contract: ListOfApisContract = {
             type: "listOfApis",
-            itemStyleView: model.itemStyleView
+            itemStyleView: model.layout,
+            allowSelection: model.allowSelection,
+            detailsPageHyperlink: model.detailsPageHyperlink
+                ? {
+                    target: model.detailsPageHyperlink.target,
+                    targetKey: model.detailsPageHyperlink.targetKey
+                }
+                : null
         };
 
         return contract;

--- a/src/components/defaultAuthenticator.ts
+++ b/src/components/defaultAuthenticator.ts
@@ -46,7 +46,7 @@ export class DefaultAuthenticator implements IAuthenticator {
         const regex = /^\w*\&(\d*)\&/gm;
         const match = regex.exec(accessToken);
 
-        if (!match && match.length < 2) {
+        if (!match || match.length < 2) {
             throw new Error(`ShredAccessSignature token format is not valid.`);
         }
 

--- a/src/components/operations/operation-details/ko/runtime/operation-details.html
+++ b/src/components/operations/operation-details/ko/runtime/operation-details.html
@@ -1,10 +1,11 @@
-<!-- ko if: operation -->
+
 
 <!-- ko if: working -->
 <spinner class="fit"></spinner>
 <!-- /ko -->
 
 <!-- ko ifnot: working -->
+<!-- ko if: operation -->
 <div class="animation-fade-in">
     <div class="operation-header">
         <h2 class="operation-name" data-bind="click: $component.openConsole">
@@ -161,7 +162,9 @@
     <!-- /ko -->
 </div>
 <!-- /ko -->
-
+<!-- ko ifnot: operation -->
+<p>No operation selected.</p>
+<!-- /ko -->
 <!-- /ko -->
 
 <!-- ko if: $component.consoleIsOpen -->

--- a/src/components/operations/operation-details/ko/runtime/operation-details.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-details.ts
@@ -67,7 +67,7 @@ export class OperationDetails {
     @OnMounted()
     public async initialize(): Promise<void> {
         await this.loadGatewayInfo();
-        
+
         const apiName = this.routeHelper.getApiName();
         const operationName = this.routeHelper.getOperationName();
 
@@ -79,7 +79,7 @@ export class OperationDetails {
 
         this.selectedApiName(apiName);
         this.selectedOperationName(operationName);
-        
+
         await this.loadApi(apiName);
         await this.loadOperation(apiName, operationName);
     }
@@ -94,8 +94,12 @@ export class OperationDetails {
         }
 
         if (apiName !== this.selectedApiName() || operationName !== this.selectedOperationName()) {
-            this.selectedOperationName(operationName);
-            this.loadOperation(apiName, operationName);
+            this.operation(null);
+           
+            if (operationName) {
+                this.selectedOperationName(operationName);
+                await this.loadOperation(apiName, operationName);
+            }
         }
     }
 
@@ -105,12 +109,7 @@ export class OperationDetails {
     }
 
     public async loadOperation(apiName: string, operationName: string): Promise<void> {
-        this.operation(null);
         this.working(true);
-
-        if (!operationName) {
-            return;
-        }
 
         const operation = await this.apiService.getOperation(`apis/${apiName}/operations/${operationName}`);
 
@@ -170,6 +169,7 @@ export class OperationDetails {
 
     private cleanSelection(): void {
         this.operation(null);
+        this.selectedOperationName(null);
         this.closeConsole();
     }
 
@@ -189,7 +189,7 @@ export class OperationDetails {
         const apiName = this.selectedApiName();
         const operationName = this.selectedOperationName();
 
-        return this.routeHelper.getDefinitionReferenceUrl(apiName, operationName, definition.name);
+        return this.routeHelper.getDefinitionAnchor(apiName, operationName, definition.name);
     }
 
     private async getProxyHostnames(): Promise<string[]> {

--- a/src/components/operations/operation-details/ko/runtime/type-definition.ts
+++ b/src/components/operations/operation-details/ko/runtime/type-definition.ts
@@ -70,6 +70,6 @@ export class TypeDefinitionViewModel {
     }
 
     public getReferenceUrl(definition: TypeDefinition): string {
-        return this.routeHelper.getDefinitionReferenceUrl(this.apiName, this.operationName, definition.referencedTypeName);
+        return this.routeHelper.getDefinitionAnchor(this.apiName, this.operationName, definition.referencedTypeName);
     }
 }

--- a/src/components/operations/operation-list/ko/operationList.html
+++ b/src/components/operations/operation-list/ko/operationList.html
@@ -1,1 +1,1 @@
-<operation-list></operation-list>
+<operation-list data-bind="attr: { params: runtimeConfig }"></operation-list>

--- a/src/components/operations/operation-list/ko/operationListEditor.html
+++ b/src/components/operations/operation-list/ko/operationListEditor.html
@@ -1,6 +1,24 @@
 <fieldset class="form flex-item flex-item-grow" data-bind="scrollable: {}">
-    <b>Coming soon</b>
-    <p>
-        An editor for this widget is not yet ready.<br />
-    </p>
+    <div class="form-group">
+        <label for="allowSelection" class="form-label">
+            <input type="checkbox" id="allowSelection" name="allowSelection" data-bind="checked: allowSelection" />
+            Allow selection
+        </label>
+    </div>
+
+    <div class="form-group">
+        <label class="form-label">
+            Link to operation details page
+            <button class="btn btn-info" type="button" title="Help"
+                data-bind="tooltipToggle: 'A link to be navigated on click.'"></button>
+        </label>
+        <div class="input-group">
+            <a href="#" class="form-control"
+                data-bind="text: hyperlinkTitle, balloon: { component: { name: 'hyperlink-selector', params: { hyperlink: $component.hyperlink, onChange: $component.onHyperlinkChange } } }">
+            </a>
+            <div class="input-group-addon">
+                <i class="paperbits-icon paperbits-link-69-2"></i>
+            </div>
+        </div>
+    </div>
 </fieldset>

--- a/src/components/operations/operation-list/ko/operationListViewModel.ts
+++ b/src/components/operations/operation-list/ko/operationListViewModel.ts
@@ -1,3 +1,4 @@
+import * as ko from "knockout";
 import template from "./operationList.html";
 import { Component } from "@paperbits/common/ko/decorators";
 
@@ -6,4 +7,9 @@ import { Component } from "@paperbits/common/ko/decorators";
     template: template
 })
 export class OperationListViewModel {
+    public readonly runtimeConfig: ko.Observable<string>;
+
+    constructor() {
+        this.runtimeConfig = ko.observable();
+    }
 }

--- a/src/components/operations/operation-list/ko/operationListViewModelBinder.ts
+++ b/src/components/operations/operation-list/ko/operationListViewModelBinder.ts
@@ -2,19 +2,30 @@ import { ViewModelBinder } from "@paperbits/common/widgets";
 import { OperationListViewModel } from "./operationListViewModel";
 import { OperationListModel } from "../operationListModel";
 import { Bag } from "@paperbits/common";
+import { EventManager } from "@paperbits/common/events";
 
 export class OperationListViewModelBinder implements ViewModelBinder<OperationListModel, OperationListViewModel> {
+    constructor(private readonly eventManager: EventManager) { }
+
     public async modelToViewModel(model: OperationListModel, viewModel?: OperationListViewModel, bindingContext?: Bag<any>): Promise<OperationListViewModel> {
         if (!viewModel) {
             viewModel = new OperationListViewModel();
         }
+
+        viewModel.runtimeConfig(JSON.stringify({
+            allowSelection: model.allowSelection,
+            detailsPageUrl: model.detailsPageHyperlink
+                ? model.detailsPageHyperlink.href
+                : undefined
+        }));
 
         viewModel["widgetBinding"] = {
             displayName: "List of operations",
             model: model,
             editor: "operation-list-editor",
             applyChanges: async (updatedModel: OperationListModel) => {
-                this.modelToViewModel(updatedModel, viewModel, bindingContext);
+                await this.modelToViewModel(updatedModel, viewModel, bindingContext);
+                this.eventManager.dispatchEvent("onContentUpdate");
             }
         };
 

--- a/src/components/operations/operation-list/operationListContract.ts
+++ b/src/components/operations/operation-list/operationListContract.ts
@@ -1,3 +1,17 @@
 import { Contract } from "@paperbits/common";
+import { HyperlinkContract } from "@paperbits/common/editing";
 
-export interface OperationListContract extends Contract { }
+/**
+ * Operation list widget configuration.
+ */
+export interface OperationListContract extends Contract {
+    /**
+     * Indicated that an operation can be selected.
+     */
+    allowSelection: boolean;
+
+    /**
+     * Link to a page that contains operation details.
+     */
+    detailsPageHyperlink?: HyperlinkContract;
+}

--- a/src/components/operations/operation-list/operationListModel.ts
+++ b/src/components/operations/operation-list/operationListModel.ts
@@ -1,1 +1,13 @@
-export class OperationListModel { }
+import { HyperlinkModel } from "@paperbits/common/permalinks";
+
+export class OperationListModel { 
+    /**
+     * Indicated that an operations can be selected.
+     */
+    public allowSelection: boolean;
+
+    /**
+     * Link to a page that contains operation details.
+     */
+    public detailsPageHyperlink: HyperlinkModel;
+}

--- a/src/components/operations/operation-list/operationListModelBinder.ts
+++ b/src/components/operations/operation-list/operationListModelBinder.ts
@@ -1,9 +1,13 @@
 import { Contract } from "@paperbits/common";
 import { IModelBinder } from "@paperbits/common/editing";
+import { IPermalinkResolver } from "@paperbits/common/permalinks";
 import { OperationListModel } from "./operationListModel";
 import { OperationListContract } from "./operationListContract";
 
+
 export class OperationListModelBinder implements IModelBinder<OperationListModel> {
+    constructor(private readonly permalinkResolver: IPermalinkResolver) { }
+
     public canHandleContract(contract: Contract): boolean {
         return contract.type === "operationList";
     }
@@ -13,12 +17,27 @@ export class OperationListModelBinder implements IModelBinder<OperationListModel
     }
 
     public async contractToModel(contract: OperationListContract): Promise<OperationListModel> {
-        return new OperationListModel();
+        const model = new OperationListModel();
+
+        model.allowSelection = contract.allowSelection;
+
+        if (contract.detailsPageHyperlink) {
+            model.detailsPageHyperlink = await this.permalinkResolver.getHyperlinkFromConfig(contract.detailsPageHyperlink);
+        }
+
+        return model;
     }
 
-    public modelToContract(model: OperationListModel): Contract {
+    public modelToContract(model: OperationListModel): OperationListContract {
         const contract: OperationListContract = {
-            type: "operationList"
+            type: "operationList",
+            allowSelection: model.allowSelection,
+            detailsPageHyperlink: model.detailsPageHyperlink
+                ? {
+                    target: model.detailsPageHyperlink.target,
+                    targetKey: model.detailsPageHyperlink.targetKey
+                }
+                : null
         };
 
         return contract;

--- a/src/components/products/product-apis/ko/productApis.html
+++ b/src/components/products/product-apis/ko/productApis.html
@@ -1,1 +1,1 @@
-<product-apis-runtime></product-apis-runtime>
+<product-apis-runtime data-bind="attr: { params: runtimeConfig }"></product-apis-runtime>

--- a/src/components/products/product-apis/ko/productApisEditor.html
+++ b/src/components/products/product-apis/ko/productApisEditor.html
@@ -1,14 +1,7 @@
 <fieldset class="form flex-item flex-item-grow" data-bind="scrollable: {}">
     <div class="form-group">
-        <label for="allowSelection" class="form-label">
-            <input type="checkbox" id="allowSelection" name="allowSelection" data-bind="checked: allowSelection" />
-            Allow selection
-        </label>
-    </div>
-
-    <div class="form-group">
         <label class="form-label">
-            Link to product details page
+            Link to API details page
             <button class="btn btn-info" type="button" title="Help"
                 data-bind="tooltipToggle: 'A link to be navigated on click.'"></button>
         </label>

--- a/src/components/products/product-apis/ko/productApisEditor.module.ts
+++ b/src/components/products/product-apis/ko/productApisEditor.module.ts
@@ -1,9 +1,10 @@
 import { IInjectorModule, IInjector } from "@paperbits/common/injection";
 import { ProductApisHandlers } from "../productApisHandlers";
+import { ProductApisEditor } from "./productApisEditor";
 
 export class ProductApisEditorModule implements IInjectorModule {
     public register(injector: IInjector): void {
-        injector.bindSingleton("productApisHandlers", ProductApisHandlers);
-        injector.bindToCollection("widgetHandlers", ProductApisHandlers);
+        injector.bind("productApisEditor", ProductApisEditor);
+        injector.bindToCollection("widgetHandlers", ProductApisHandlers, "productApisHandlers");
     }
 }

--- a/src/components/products/product-apis/ko/productApisEditor.ts
+++ b/src/components/products/product-apis/ko/productApisEditor.ts
@@ -1,41 +1,35 @@
 import * as ko from "knockout";
-import template from "./operationListEditor.html";
+import template from "./productApisEditor.html";
 import { Component, OnMounted, Param, Event } from "@paperbits/common/ko/decorators";
-import { OperationListModel } from "../operationListModel";
+import { ProductApisModel } from "../productApisModel";
 import { HyperlinkModel } from "@paperbits/common/permalinks";
 
 @Component({
-    selector: "operation-list-editor",
+    selector: "product-apis-editor",
     template: template,
-    injectable: "operationListEditor"
+    injectable: "productApisEditor"
 })
-export class OperationListEditor {
-    public readonly allowSelection: ko.Observable<boolean>;
+export class ProductApisEditor {
     public readonly hyperlink: ko.Observable<HyperlinkModel>;
     public readonly hyperlinkTitle: ko.Computed<string>;
 
     constructor() {
-        this.allowSelection = ko.observable(false);
         this.hyperlink = ko.observable();
         this.hyperlinkTitle = ko.computed<string>(() => this.hyperlink() ? this.hyperlink().title : "Add a link...");
     }
 
     @Param()
-    public model: OperationListModel;
+    public model: ProductApisModel;
 
     @Event()
-    public onChange: (model: OperationListModel) => void;
+    public onChange: (model: ProductApisModel) => void;
 
     @OnMounted()
     public async initialize(): Promise<void> {
-        this.allowSelection(this.model.allowSelection);
         this.hyperlink(this.model.detailsPageHyperlink);
-
-        this.allowSelection.subscribe(this.applyChanges);
     }
 
     private applyChanges(): void {
-        this.model.allowSelection = this.allowSelection();
         this.model.detailsPageHyperlink = this.hyperlink();
         this.onChange(this.model);
     }

--- a/src/components/products/product-apis/ko/productApisViewModel.ts
+++ b/src/components/products/product-apis/ko/productApisViewModel.ts
@@ -1,3 +1,4 @@
+import * as ko from "knockout";
 import template from "./productApis.html";
 import { Component } from "@paperbits/common/ko/decorators/component.decorator";
 
@@ -6,4 +7,10 @@ import { Component } from "@paperbits/common/ko/decorators/component.decorator";
     template: template,
     injectable: "productApis"
 })
-export class ProductApisViewModel { }
+export class ProductApisViewModel {
+    public readonly runtimeConfig: ko.Observable<string>;
+
+    constructor() {
+        this.runtimeConfig = ko.observable();
+    }
+ }

--- a/src/components/products/product-apis/ko/productApisViewModelBinder.ts
+++ b/src/components/products/product-apis/ko/productApisViewModelBinder.ts
@@ -1,19 +1,30 @@
+import { Bag } from "@paperbits/common";
+import { EventManager } from "@paperbits/common/events";
 import { ViewModelBinder } from "@paperbits/common/widgets";
 import { ProductApisViewModel } from "./productApisViewModel";
 import { ProductApisModel } from "../productApisModel";
-import { Bag } from "@paperbits/common";
 
 export class ProductApisViewModelBinder implements ViewModelBinder<ProductApisModel, ProductApisViewModel> {
+    constructor(private readonly eventManager: EventManager) { }
+    
     public async modelToViewModel(model: ProductApisModel, viewModel?: ProductApisViewModel, bindingContext?: Bag<any>): Promise<ProductApisViewModel> {
         if (!viewModel) {
             viewModel = new ProductApisViewModel();
         }
 
+        viewModel.runtimeConfig(JSON.stringify({
+            detailsPageUrl: model.detailsPageHyperlink
+                ? model.detailsPageHyperlink.href
+                : undefined
+        }));
+
         viewModel["widgetBinding"] = {
             displayName: "Product: APIs",
             model: model,
+            editor: "product-apis-editor",
             applyChanges: async (updatedModel: ProductApisModel) => {
-                this.modelToViewModel(updatedModel, viewModel, bindingContext);
+                await this.modelToViewModel(updatedModel, viewModel, bindingContext);
+                this.eventManager.dispatchEvent("onContentUpdate");
             }
         };
 

--- a/src/components/products/product-apis/ko/runtime/product-apis.ts
+++ b/src/components/products/product-apis/ko/runtime/product-apis.ts
@@ -1,7 +1,7 @@
 import * as ko from "knockout";
 import * as Constants from "../../../../../constants";
 import template from "./product-apis.html";
-import { Component, RuntimeComponent, OnMounted, OnDestroyed } from "@paperbits/common/ko/decorators";
+import { Component, RuntimeComponent, OnMounted, OnDestroyed, Param } from "@paperbits/common/ko/decorators";
 import { Router } from "@paperbits/common/routing";
 import { ApiService } from "../../../../../services/apiService";
 import { Api } from "../../../../../models/api";
@@ -29,6 +29,7 @@ export class ProductApis {
         private readonly router: Router,
         private readonly routeHelper: RouteHelper
     ) {
+        this.detailsPageUrl = ko.observable();
         this.apis = ko.observableArray([]);
         this.working = ko.observable();
         this.pattern = ko.observable();
@@ -38,10 +39,13 @@ export class ProductApis {
         this.hasPager = ko.computed(() => this.hasPrevPage() || this.hasNextPage());
     }
 
+    @Param()
+    public detailsPageUrl: ko.Observable<string>;
+
     @OnMounted()
     public async initialize(): Promise<void> {
         await this.searchApis();
-        
+
         this.router.addRouteChangeListener(this.searchApis);
 
         this.pattern
@@ -82,7 +86,7 @@ export class ProductApis {
             this.apis(pageOfApis.value);
 
             const nextLink = pageOfApis.nextLink;
-            
+
             this.hasPrevPage(pageNumber > 0);
             this.hasNextPage(!!nextLink);
         }
@@ -95,9 +99,9 @@ export class ProductApis {
     }
 
     public getReferenceUrl(api: Api): string {
-        return this.routeHelper.getApiReferenceUrl(api.name);
+        return this.routeHelper.getApiReferenceUrl(api.name, this.detailsPageUrl());
     }
-    
+
     public prevPage(): void {
         this.page(this.page() - 1);
         this.loadPageOfApis();

--- a/src/components/products/product-apis/productApisContract.ts
+++ b/src/components/products/product-apis/productApisContract.ts
@@ -1,3 +1,12 @@
 import { Contract } from "@paperbits/common";
+import { HyperlinkContract } from "@paperbits/common/editing";
 
-export interface ProductApisContract extends Contract { }
+/**
+ * Product API list widget configuration.
+ */
+export interface ProductApisContract extends Contract {
+    /**
+     * Link to a page that contains operation details.
+     */
+    detailsPageHyperlink?: HyperlinkContract;
+}

--- a/src/components/products/product-apis/productApisModel.ts
+++ b/src/components/products/product-apis/productApisModel.ts
@@ -1,1 +1,11 @@
-export class ProductApisModel { }
+import { HyperlinkModel } from "@paperbits/common/permalinks";
+
+/**
+ * Product API list widget configuration.
+ */
+export class ProductApisModel {
+    /**
+     * Link to a page that contains API details.
+     */
+    public detailsPageHyperlink: HyperlinkModel;
+}

--- a/src/components/products/product-apis/productApisModelBinder.ts
+++ b/src/components/products/product-apis/productApisModelBinder.ts
@@ -1,9 +1,12 @@
 import { Contract } from "@paperbits/common";
 import { IModelBinder } from "@paperbits/common/editing";
+import { IPermalinkResolver } from "@paperbits/common/permalinks";
 import { ProductApisModel } from "./productApisModel";
 import { ProductApisContract } from "./productApisContract";
 
 export class ProductApisModelBinder implements IModelBinder<ProductApisModel> {
+    constructor(private readonly permalinkResolver: IPermalinkResolver) { }
+    
     public canHandleContract(contract: Contract): boolean {
         return contract.type === "product-apis";
     }
@@ -13,12 +16,24 @@ export class ProductApisModelBinder implements IModelBinder<ProductApisModel> {
     }
 
     public async contractToModel(contract: ProductApisContract): Promise<ProductApisModel> {
-        return new ProductApisModel();
+        const model = new ProductApisModel();
+
+        if (contract.detailsPageHyperlink) {
+            model.detailsPageHyperlink = await this.permalinkResolver.getHyperlinkFromConfig(contract.detailsPageHyperlink);
+        }
+
+        return model;
     }
 
-    public modelToContract(model: ProductApisModel): Contract {
+    public modelToContract(model: ProductApisModel): ProductApisContract {
         const contract: ProductApisContract = {
-            type: "product-apis"
+            type: "product-apis",
+            detailsPageHyperlink: model.detailsPageHyperlink
+            ? {
+                target: model.detailsPageHyperlink.target,
+                targetKey: model.detailsPageHyperlink.targetKey
+            }
+            : null
         };
 
         return contract;

--- a/src/components/products/product-list/ko/productList.html
+++ b/src/components/products/product-list/ko/productList.html
@@ -1,8 +1,7 @@
-<!-- ko if: itemStyleView() === 'list' -->
-<product-list-runtime></product-list-runtime>
+<!-- ko if: layout() === 'list' -->
+<product-list-runtime data-bind="attr: { params: runtimeConfig }"></product-list-runtime>
 <!-- /ko -->
 
-
-<!-- ko if: itemStyleView() === 'dropdown' -->
-<product-list-dropdown-runtime></product-list-dropdown-runtime>
+<!-- ko if: layout() === 'dropdown' -->
+<product-list-dropdown-runtime data-bind="attr: { params: runtimeConfig }"></product-list-dropdown-runtime>
 <!-- /ko -->

--- a/src/components/products/product-list/ko/productListEditor.ts
+++ b/src/components/products/product-list/ko/productListEditor.ts
@@ -1,8 +1,9 @@
 import * as ko from "knockout";
 import template from "./productListEditor.html";
-import { StyleService } from "@paperbits/styles";
 import { Component, OnMounted, Param, Event } from "@paperbits/common/ko/decorators";
+import { HyperlinkModel } from "@paperbits/common/permalinks";
 import { ProductListModel } from "../productListModel";
+
 
 @Component({
     selector: "product-list-editor",
@@ -10,7 +11,15 @@ import { ProductListModel } from "../productListModel";
     injectable: "productListEditor"
 })
 export class ProductListEditor {
-    constructor(private readonly styleService: StyleService) { }
+    public readonly allowSelection: ko.Observable<boolean>;
+    public readonly hyperlink: ko.Observable<HyperlinkModel>;
+    public readonly hyperlinkTitle: ko.Computed<string>;
+
+    constructor() {
+        this.allowSelection = ko.observable(false);
+        this.hyperlink = ko.observable();
+        this.hyperlinkTitle = ko.computed<string>(() => this.hyperlink() ? this.hyperlink().title : "Add a link...");
+    }
 
     @Param()
     public model: ProductListModel;
@@ -20,11 +29,20 @@ export class ProductListEditor {
 
     @OnMounted()
     public async initialize(): Promise<void> {
-        // TODO: Implement
+        this.allowSelection(this.model.allowSelection);
+        this.hyperlink(this.model.detailsPageHyperlink);
+
+        this.allowSelection.subscribe(this.applyChanges);
     }
 
     private applyChanges(): void {
-        // TODO: Implement
+        this.model.allowSelection = this.allowSelection();
+        this.model.detailsPageHyperlink = this.hyperlink();
         this.onChange(this.model);
+    }
+
+    public onHyperlinkChange(hyperlink: HyperlinkModel): void {
+        this.hyperlink(hyperlink);
+        this.applyChanges();
     }
 }

--- a/src/components/products/product-list/ko/productListViewModel.ts
+++ b/src/components/products/product-list/ko/productListViewModel.ts
@@ -7,9 +7,11 @@ import { Component } from "@paperbits/common/ko/decorators";
     template: template
 })
 export class ProductListViewModel {    
-    public itemStyleView: ko.Observable<string>;
+    public readonly layout: ko.Observable<string>;
+    public readonly runtimeConfig: ko.Observable<string>;
 
     constructor() {        
-        this.itemStyleView = ko.observable();
+        this.layout = ko.observable();
+        this.runtimeConfig = ko.observable();
     }
 }

--- a/src/components/products/product-list/ko/productListViewModelBinder.ts
+++ b/src/components/products/product-list/ko/productListViewModelBinder.ts
@@ -1,22 +1,35 @@
+import { Bag } from "@paperbits/common";
 import { ViewModelBinder } from "@paperbits/common/widgets";
+import { EventManager } from "@paperbits/common/events";
 import { ProductListViewModel } from "./productListViewModel";
 import { ProductListModel } from "../productListModel";
-import { Bag } from "@paperbits/common";
+
 
 export class ProductListViewModelBinder implements ViewModelBinder<ProductListModel, ProductListViewModel> {
+    constructor(private readonly eventManager: EventManager) { }
+    
     public async modelToViewModel(model: ProductListModel, viewModel?: ProductListViewModel, bindingContext?: Bag<any>): Promise<ProductListViewModel> {
         if (!viewModel) {
             viewModel = new ProductListViewModel();
         }
 
-        viewModel.itemStyleView(model.itemStyleView);
+        viewModel.layout(model.layout);
+
+        viewModel.runtimeConfig(JSON.stringify({
+            allowSelection: model.allowSelection,
+            detailsPageUrl: model.detailsPageHyperlink
+                ? model.detailsPageHyperlink.href
+                : undefined
+        }));
+
 
         viewModel["widgetBinding"] = {
             displayName: "List of products",
             model: model,
             editor: "product-list-editor",
             applyChanges: async (updatedModel: ProductListModel) => {
-                this.modelToViewModel(updatedModel, viewModel, bindingContext);
+                await this.modelToViewModel(updatedModel, viewModel, bindingContext);
+                this.eventManager.dispatchEvent("onContentUpdate");
             }
         };
 

--- a/src/components/products/product-list/ko/runtime/product-list.ts
+++ b/src/components/products/product-list/ko/runtime/product-list.ts
@@ -1,7 +1,7 @@
 import * as ko from "knockout";
 import * as Constants from "../../../../../constants";
 import template from "./product-list.html";
-import { Component, RuntimeComponent, OnMounted } from "@paperbits/common/ko/decorators";
+import { Component, RuntimeComponent, OnMounted, Param } from "@paperbits/common/ko/decorators";
 import { Product } from "../../../../../models/product";
 import { ProductService } from "../../../../../services/productService";
 import { UsersService } from "../../../../../services/usersService";
@@ -35,8 +35,10 @@ export class ProductList {
         private readonly router: Router,
         private readonly routeHelper: RouteHelper
     ) {
+        this.detailsPageUrl = ko.observable();
+        this.allowSelection = ko.observable(false);
         this.products = ko.observableArray();
-        this.selectedProductName = ko.observable();
+        this.selectedProductName = ko.observable().extend(<any>{ acceptChange: this.allowSelection });
         this.working = ko.observable(true);
         this.pattern = ko.observable();
         this.page = ko.observable(1);
@@ -44,6 +46,12 @@ export class ProductList {
         this.hasNextPage = ko.observable(false);
         this.hasPager = ko.computed(() => this.hasPrevPage() || this.hasNextPage());
     }
+
+    @Param()
+    public allowSelection: ko.Observable<boolean>;
+
+    @Param()
+    public detailsPageUrl: ko.Observable<string>;
 
     @OnMounted()
     public async initialize(): Promise<void> {
@@ -73,7 +81,7 @@ export class ProductList {
 
             this.products(itemsPage.value);
 
-            if (!this.selectedProductName()) {
+            if (this.allowSelection() && !this.selectedProductName()) {
                 this.selectFirstProduct();
             }
         }
@@ -97,12 +105,12 @@ export class ProductList {
 
         this.selectedProductName(productName);
 
-        const productUrl = this.routeHelper.getProductReferenceUrl(productName);
+        const productUrl = this.routeHelper.getProductReferenceUrl(productName, this.detailsPageUrl());
         this.router.navigateTo(productUrl);
     }
 
     public getProductUrl(product: Product): string {
-        return this.routeHelper.getProductReferenceUrl(product.name);
+        return this.routeHelper.getProductReferenceUrl(product.name, this.detailsPageUrl());
     }
 
     public prevPage(): void {

--- a/src/components/products/product-list/productListContract.ts
+++ b/src/components/products/product-list/productListContract.ts
@@ -1,5 +1,22 @@
 import { Contract } from "@paperbits/common";
+import { HyperlinkContract } from "@paperbits/common/editing";
 
+/**
+ * Product list widget configuration.
+ */
 export interface ProductListContract extends Contract {
+    /**
+     * Product list layout, e.g. "list", "dropdown".
+     */
     itemStyleView?: string;
+
+    /**
+     * Indicated that a product can be selected.
+     */
+    allowSelection: boolean;
+
+    /**
+     * Link to a page that contains operation details.
+     */
+    detailsPageHyperlink?: HyperlinkContract;
 }

--- a/src/components/products/product-list/productListModel.ts
+++ b/src/components/products/product-list/productListModel.ts
@@ -1,7 +1,25 @@
-export class ProductListModel {
-    public itemStyleView?: string;
+import { HyperlinkModel } from "@paperbits/common/permalinks";
 
-    constructor(itemStyleView: string = "list") {
-        this.itemStyleView = itemStyleView;
+/**
+ * Product list widget configuration.
+ */
+export class ProductListModel {
+    /**
+     * Product list layout, e.g. "list", "dropdown".
+     */
+    public layout?: string;
+
+    /**
+     * Indicated that a product can be selected.
+     */
+    public allowSelection: boolean;
+
+    /**
+     * Link to a page that contains operation details.
+     */
+    public detailsPageHyperlink: HyperlinkModel;
+
+    constructor(layout: string = "list") {
+        this.layout = layout;
     }
 }

--- a/src/components/products/product-list/productListModelBinder.ts
+++ b/src/components/products/product-list/productListModelBinder.ts
@@ -1,9 +1,13 @@
 import { Contract } from "@paperbits/common";
 import { IModelBinder } from "@paperbits/common/editing";
+import { IPermalinkResolver } from "@paperbits/common/permalinks";
 import { ProductListModel } from "./productListModel";
 import { ProductListContract } from "./productListContract";
 
+
 export class ProductListModelBinder implements IModelBinder<ProductListModel> {
+    constructor(private readonly permalinkResolver: IPermalinkResolver) { }
+    
     public canHandleModel(model: Object): boolean {
         return model instanceof ProductListModel;
     }
@@ -15,14 +19,29 @@ export class ProductListModelBinder implements IModelBinder<ProductListModel> {
 
     public async contractToModel(contract: ProductListContract): Promise<ProductListModel> {
         const model = new ProductListModel();
-        model.itemStyleView = contract.itemStyleView;
+
+        model.layout = contract.itemStyleView;
+
+        model.allowSelection = contract.allowSelection;
+
+        if (contract.detailsPageHyperlink) {
+            model.detailsPageHyperlink = await this.permalinkResolver.getHyperlinkFromConfig(contract.detailsPageHyperlink);
+        }
+
         return model;
     }
 
     public modelToContract(model: ProductListModel): Contract {
         const contract: ProductListContract = {
             type: "product-list",
-            itemStyleView: model.itemStyleView
+            itemStyleView: model.layout,
+            allowSelection: model.allowSelection,
+            detailsPageHyperlink: model.detailsPageHyperlink
+                ? {
+                    target: model.detailsPageHyperlink.target,
+                    targetKey: model.detailsPageHyperlink.targetKey
+                }
+                : null
         };
 
         return contract;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,6 +28,5 @@ export const pageUrlChangePassword = "/change-password";
  * Maximum number of items to show in a paginated view.
  */
 export const defaultPageSize = 50;
-export const apiDetailsPageUrl = "/reference";
-export const productDetailsPageUrl = "/product";
+
 export const defaultInputDelayMs = 600;

--- a/src/logging/appInsightsLogger.ts
+++ b/src/logging/appInsightsLogger.ts
@@ -1,14 +1,10 @@
 import { Bag } from "@paperbits/common";
 import { Logger } from "@paperbits/common/logging";
 import { AppInsights } from "applicationinsights-js";
-import { TenantService } from "../services/tenantService";
 
 
 export class LogService implements Logger {
-    constructor(
-        private readonly instrumentationKey: string,
-        private readonly tenantService: TenantService
-    ) {
+    constructor(private readonly instrumentationKey: string) {
         if (this.instrumentationKey && location.hostname.endsWith(".net")) {
             AppInsights.downloadAndSetup({ instrumentationKey: this.instrumentationKey });
         }

--- a/src/routing/routeHelper.ts
+++ b/src/routing/routeHelper.ts
@@ -24,7 +24,7 @@ export class RouteHelper {
         return this.getHashParameter("product");
     }
 
-    public getApiReferenceUrl(apiName: string): string {
+    public getApiReferenceUrl(apiName: string, detailsPageUrl: string = ""): string {
         if (!apiName) {
             throw new Error(`Parameter "apiName" not specified.`);
         }
@@ -32,8 +32,8 @@ export class RouteHelper {
         let path = "";
         const currentPath = this.router.getPath();
 
-        if (currentPath !== Constants.apiDetailsPageUrl) {
-            path = Constants.apiDetailsPageUrl;
+        if (currentPath !== detailsPageUrl) {
+            path = detailsPageUrl;
         }
 
         if (currentPath.endsWith("/")) {
@@ -43,7 +43,7 @@ export class RouteHelper {
         return `${path}#api=${apiName}`;
     }
 
-    public getOperationReferenceUrl(apiName: string, operationName: string): string {
+    public getOperationReferenceUrl(apiName: string, operationName: string, detailsPageUrl: string = ""): string {
         if (!apiName) {
             throw new Error(`Parameter "apiName" not specified.`);
         }
@@ -55,8 +55,8 @@ export class RouteHelper {
         let path = "";
         const currentPath = this.router.getPath();
 
-        if (currentPath !== Constants.apiDetailsPageUrl) {
-            path = Constants.apiDetailsPageUrl;
+        if (currentPath !== detailsPageUrl) {
+            path = detailsPageUrl;
         }
 
         if (currentPath.endsWith("/")) {
@@ -82,7 +82,7 @@ export class RouteHelper {
         return `api=${apiName}&operation=${operationName}&definition=${definitionName}`;
     }
 
-    public getDefinitionReferenceUrl(apiName: string, operationName: string, definitionName: string): string {
+    public getDefinitionAnchor(apiName: string, operationName: string, definitionName: string): string {
         if (!apiName) {
             throw new Error(`Parameter "apiName" not specified.`);
         }
@@ -95,26 +95,19 @@ export class RouteHelper {
             throw new Error(`Parameter "definitionName" not specified.`);
         }
 
-        let path = "";
-        const currentPath = this.router.getPath();
-
-        if (currentPath !== Constants.apiDetailsPageUrl) {
-            path = Constants.apiDetailsPageUrl;
-        }
-
-        if (currentPath.endsWith("/")) {
-            path = Utils.ensureTrailingSlash(path);
-        }
-
-        return `${path}#api=${apiName}&operation=${operationName}&definition=${definitionName}`;
+        return `#api=${apiName}&operation=${operationName}&definition=${definitionName}`;
     }
 
-    public getProductReferenceUrl(productName: string): string {
+    public getProductReferenceUrl(productName: string, detailsPageUrl: string = ""): string {
+        if (!productName) {
+            throw new Error(`Parameter "productName" not specified.`);
+        }
+
         let path = "";
         const currentPath = this.router.getPath();
 
-        if (currentPath !== Constants.productDetailsPageUrl) {
-            path = Constants.productDetailsPageUrl;
+        if (currentPath !== detailsPageUrl) {
+            path = detailsPageUrl;
         }
 
         if (currentPath.endsWith("/")) {

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -66,7 +66,7 @@ export class ApiService {
         if (!versionSetId) {
             return null;
         }
-        
+
         const query = "/apis?expandApiVersionSet=true";
         const apisPage = await this.mapiClient.get<Page<ApiContract>>(query);
         const result = apisPage.value.filter(x => x.properties.apiVersionSetId && Utils.getResourceName("api-version-sets", x.properties.apiVersionSetId, "shortId") === versionSetId).map(x => new Api(x));
@@ -109,8 +109,8 @@ export class ApiService {
         const tagGroups: Bag<TagGroup<Operation>> = {};
 
         pagesOfOperationsByTag.value.forEach(x => {
-            const tagContract: TagContract = x.tag ? Utils.armifyContract(x.tag) : null;
-            const operationContract: OperationContract = x.operation ? Utils.armifyContract(x.operation) : null;
+            const tagContract: TagContract = x.tag ? Utils.armifyContract("tags", x.tag) : null;
+            const operationContract: OperationContract = x.operation ? Utils.armifyContract("operations", x.operation) : null;
 
             let tagGroup: TagGroup<Operation>;
             let tagName: string;
@@ -168,9 +168,9 @@ export class ApiService {
         const page = new Page<TagGroup<Api>>();
         const tagGroups: Bag<TagGroup<Api>> = {};
 
-        pageOfApiTagResources.value.forEach(x => {
-            const tagContract: TagContract = x.tag ? Utils.armifyContract(x.tag) : null;
-            const apiContract: ApiContract = x.api ? Utils.armifyContract(x.api) : null;
+        pageOfApiTagResources.value.forEach((x) => {
+            const tagContract: TagContract = x.tag ? Utils.armifyContract("tags", x.tag) : null;
+            const apiContract: ApiContract = x.api ? Utils.armifyContract("apis", x.api) : null;
 
             let tagGroup: TagGroup<Api>;
             let tagName: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { ArmResource } from "./contracts/armResource";
 import { NameValuePair } from "request";
 import { JwtToken } from "./contracts/jwtToken";
 import { js } from "js-beautify";
@@ -301,20 +302,15 @@ export class Utils {
         return resourceUrl;
     }
 
-    public static armifyContract(contract: any): any {
-        const armifiedContract = {};
+    public static armifyContract(resource: string, contract: any): ArmResource {
+        contract = Utils.clone(contract);
+        contract.displayName = contract.name;
 
-        if (contract.id) {
-            const segments = contract.id.split("/");
-            armifiedContract["id"] = contract.id;
-            armifiedContract["name"] = segments[segments.length - 1];
-        }
-
-        if (contract.name) {
-            contract.displayName = contract.name;
-        }
-
-        armifiedContract["properties"] = contract;
+        const armifiedContract: ArmResource = {
+            id: contract.id,
+            name: this.getResourceName(resource, contract.id, "name"),
+            properties: contract
+        };
 
         delete contract.id;
         delete contract.name;
@@ -330,5 +326,9 @@ export class Utils {
     public static formatDateTime(time: string): string {
         const options = { weekday: "long", year: "numeric", month: "long", day: "numeric" };
         return new Date(time).toLocaleDateString("en-US", options);
+    }
+
+    public static clone(obj: Object): Object {
+        return JSON.parse(JSON.stringify(obj));
     }
 }


### PR DESCRIPTION
- Fixed path to the media files folder in generate.bat file;
- Added an ability to specify the target details page for list widgets: APIs, Operations, Products, Product APIs.
![image](https://user-images.githubusercontent.com/2320302/67625062-ee5ea280-f7ed-11e9-9976-ae5444204e8f.png)