### PR TITLE
Switched to adal-vanilla.js library for AAD authentication.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -506,6 +506,11 @@
             "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
             "dev": true
         },
+        "adal-vanilla": {
+            "version": "1.0.18",
+            "resolved": "https://registry.npmjs.org/adal-vanilla/-/adal-vanilla-1.0.18.tgz",
+            "integrity": "sha512-6NEPtEZR9tVwOQRZAG5GjDrQQ4KjBlnNBvtUn+Tc66WyUrhbpzxDj9WPbbF99CBFdvIaPA0ncjf3FSI+F9zoYQ=="
+        },
         "aggregate-error": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "@paperbits/prosemirror": "0.1.169",
         "@paperbits/styles": "0.1.169",
         "@webcomponents/webcomponentsjs": "^2.3.0",
+        "adal-vanilla": "^1.0.18",
         "applicationinsights-js": "^1.0.20",
         "core-js": "^3.3.6",
         "d3": "^5.12.0",

--- a/src/components/users/user-signin-social/ko/runtime/signin-aad.ts
+++ b/src/components/users/user-signin-social/ko/runtime/signin-aad.ts
@@ -38,7 +38,7 @@ export class SignInAad {
         this.cleanValidationErrors();
 
         try {
-            await this.aadService.signInWithAad(this.clientId(), this.signinTenant());
+            await this.aadService.signInWithAadAdal(this.clientId(), this.signinTenant());
         }
         catch (error) {
             const validationReport: ValidationReport = {

--- a/src/components/users/user-signin/ko/runtime/user-signin.ts
+++ b/src/components/users/user-signin/ko/runtime/user-signin.ts
@@ -1,10 +1,10 @@
 import * as ko from "knockout";
 import * as validation from "knockout.validation";
 import template from "./user-signin.html";
+import { EventManager } from "@paperbits/common/events";
 import { Component, RuntimeComponent, OnMounted, Param } from "@paperbits/common/ko/decorators";
 import { UsersService } from "../../../../../services/usersService";
 import { MapiError } from "../../../../../services/mapiError";
-import { EventManager } from "@paperbits/common/events";
 import { ValidationReport } from "../../../../../contracts/validationReport";
 
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,11 @@ export enum IdentityProviders {
     aadB2C = "AadB2C"
 }
 
+export enum AadEndpoints {
+    primary = "login.microsoftonline.com",
+    legacy = "login.windows.net"
+}
+
 export const hashSignOut = "signout";
 export const pageUrlSignIn = "/signin";
 export const pageUrlSignInSso = "/signinsso";


### PR DESCRIPTION
It turned out that MSAL library doesn't support legacy tokens and doesn't provide enough control over the token generation. At the same time, APIM backend doesn't support JWT tokens of version 2.0. Therefore, as a temporary solution, we will use both libraries ADAL (for AAD) and MSAL (for AAD B2C).

Closes #298.