### PR TITLE
Fixed check for token expiration date time.

### DIFF
--- a/src/components/defaultAuthenticator.ts
+++ b/src/components/defaultAuthenticator.ts
@@ -28,7 +28,7 @@ export class DefaultAuthenticator implements IAuthenticator {
             return false;
         }
 
-        const now = new Date();
+        const now = Utils.getUtcDateTime();
 
         return now < parsedToken.expires;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -331,4 +331,11 @@ export class Utils {
     public static clone(obj: Object): Object {
         return JSON.parse(JSON.stringify(obj));
     }
+
+    public static getUtcDateTime(): Date {
+        const now = new Date();
+        const utc = new Date(now.getTime() + now.getTimezoneOffset() * 60000);
+
+        return utc;
+    }
 }


### PR DESCRIPTION
There is an issue comparing token expiration date-time (UTC time) with browser date-time (local time) which may result into inability to authenticate.

Closes #293.