### PR TITLE
Allow the operation-list group by tag to be enabled by default

### DIFF
--- a/src/components/operations/operation-list/ko/operationListEditor.html
+++ b/src/components/operations/operation-list/ko/operationListEditor.html
@@ -7,6 +7,13 @@
     </div>
 
     <div class="form-group">
+        <label for="defaultGroupByTagToEnabled" class="form-label">
+            <input type="checkbox" id="defaultGroupByTagToEnabled" name="defaultGroupByTagToEnabled" data-bind="checked: defaultGroupByTagToEnabled" />
+            Default Group by tag to enabled
+        </label>
+    </div>
+
+    <div class="form-group">
         <label class="form-label">
             Link to operation details page
             <button class="btn btn-info" type="button" title="Help"

--- a/src/components/operations/operation-list/ko/operationListEditor.ts
+++ b/src/components/operations/operation-list/ko/operationListEditor.ts
@@ -11,11 +11,13 @@ import { HyperlinkModel } from "@paperbits/common/permalinks";
 })
 export class OperationListEditor {
     public readonly allowSelection: ko.Observable<boolean>;
+    public readonly defaultGroupByTagToEnabled: ko.Observable<boolean>;
     public readonly hyperlink: ko.Observable<HyperlinkModel>;
     public readonly hyperlinkTitle: ko.Computed<string>;
 
     constructor() {
         this.allowSelection = ko.observable(false);
+        this.defaultGroupByTagToEnabled = ko.observable(false);
         this.hyperlink = ko.observable();
         this.hyperlinkTitle = ko.computed<string>(() => this.hyperlink() ? this.hyperlink().title : "Add a link...");
     }
@@ -29,13 +31,16 @@ export class OperationListEditor {
     @OnMounted()
     public async initialize(): Promise<void> {
         this.allowSelection(this.model.allowSelection);
+        this.defaultGroupByTagToEnabled(this.model.defaultGroupByTagToEnabled);
         this.hyperlink(this.model.detailsPageHyperlink);
 
         this.allowSelection.subscribe(this.applyChanges);
+        this.defaultGroupByTagToEnabled.subscribe(this.applyChanges);
     }
 
     private applyChanges(): void {
         this.model.allowSelection = this.allowSelection();
+        this.model.defaultGroupByTagToEnabled = this.defaultGroupByTagToEnabled();
         this.model.detailsPageHyperlink = this.hyperlink();
         this.onChange(this.model);
     }

--- a/src/components/operations/operation-list/ko/operationListViewModelBinder.ts
+++ b/src/components/operations/operation-list/ko/operationListViewModelBinder.ts
@@ -14,6 +14,7 @@ export class OperationListViewModelBinder implements ViewModelBinder<OperationLi
 
         viewModel.runtimeConfig(JSON.stringify({
             allowSelection: model.allowSelection,
+            defaultGroupByTagToEnabled: model.defaultGroupByTagToEnabled,
             detailsPageUrl: model.detailsPageHyperlink
                 ? model.detailsPageHyperlink.href
                 : undefined

--- a/src/components/operations/operation-list/ko/runtime/operation-list.ts
+++ b/src/components/operations/operation-list/ko/runtime/operation-list.ts
@@ -44,6 +44,7 @@ export class OperationList {
         this.selectedOperationName = ko.observable().extend(<any>{ acceptChange: this.allowSelection });
         this.working = ko.observable(false);
         this.groupByTag = ko.observable(false);
+        this.defaultGroupByTagToEnabled = ko.observable(false);
         this.pattern = ko.observable();
         this.pageNumber = ko.observable(1);
         this.hasNextPage = ko.observable();
@@ -53,6 +54,9 @@ export class OperationList {
 
     @Param()
     public allowSelection: ko.Observable<boolean>;
+
+    @Param()
+    public defaultGroupByTagToEnabled: ko.Observable<boolean>;
 
     @Param()
     public detailsPageUrl: ko.Observable<string>;
@@ -68,6 +72,8 @@ export class OperationList {
         if (!this.selectedApiName()) {
             return;
         }
+
+        this.groupByTag(this.defaultGroupByTagToEnabled());
 
         await this.loadOperations();
 

--- a/src/components/operations/operation-list/operationListContract.ts
+++ b/src/components/operations/operation-list/operationListContract.ts
@@ -11,6 +11,11 @@ export interface OperationListContract extends Contract {
     allowSelection: boolean;
 
     /**
+     * Default GroupByTag to enabled.
+     */
+    defaultGroupByTagToEnabled?: boolean;
+
+    /**
      * Link to a page that contains operation details.
      */
     detailsPageHyperlink?: HyperlinkContract;

--- a/src/components/operations/operation-list/operationListModel.ts
+++ b/src/components/operations/operation-list/operationListModel.ts
@@ -7,6 +7,11 @@ export class OperationListModel {
     public allowSelection: boolean;
 
     /**
+     * Default GroupByTag to enabled.
+     */
+    public defaultGroupByTagToEnabled: boolean;
+
+    /**
      * Link to a page that contains operation details.
      */
     public detailsPageHyperlink: HyperlinkModel;

--- a/src/components/operations/operation-list/operationListModelBinder.ts
+++ b/src/components/operations/operation-list/operationListModelBinder.ts
@@ -20,6 +20,7 @@ export class OperationListModelBinder implements IModelBinder<OperationListModel
         const model = new OperationListModel();
 
         model.allowSelection = contract.allowSelection;
+        model.defaultGroupByTagToEnabled = contract.defaultGroupByTagToEnabled === true;
 
         if (contract.detailsPageHyperlink) {
             model.detailsPageHyperlink = await this.permalinkResolver.getHyperlinkFromConfig(contract.detailsPageHyperlink);
@@ -32,6 +33,7 @@ export class OperationListModelBinder implements IModelBinder<OperationListModel
         const contract: OperationListContract = {
             type: "operationList",
             allowSelection: model.allowSelection,
+            defaultGroupByTagToEnabled: model.defaultGroupByTagToEnabled,
             detailsPageHyperlink: model.detailsPageHyperlink
                 ? {
                     target: model.detailsPageHyperlink.target,


### PR DESCRIPTION
Feature enhancement to allow the group by tag toggle to be enabled by default on the operation list page.