### PR TITLE
Allow the list-of-apis group by tag to be enabled by default

### DIFF
--- a/src/components/apis/list-of-apis/ko/listOfApisEditor.html
+++ b/src/components/apis/list-of-apis/ko/listOfApisEditor.html
@@ -7,6 +7,13 @@
     </div>
 
     <div class="form-group">
+        <label for="defaultGroupByTagToEnabled" class="form-label">
+            <input type="checkbox" id="defaultGroupByTagToEnabled" name="defaultGroupByTagToEnabled" data-bind="checked: defaultGroupByTagToEnabled" />
+            Default Group by tag to enabled
+        </label>
+    </div>
+
+    <div class="form-group">
         <label class="form-label">
             Link to API details page
             <button class="btn btn-info" type="button" title="Help"

--- a/src/components/apis/list-of-apis/ko/listOfApisEditor.ts
+++ b/src/components/apis/list-of-apis/ko/listOfApisEditor.ts
@@ -14,11 +14,13 @@ export class ListOfApisEditor {
     public readonly itemStyles: ko.ObservableArray<any>;
     public readonly itemStyle: ko.Observable<string>;
     public readonly allowSelection: ko.Observable<boolean>;
+    public readonly defaultGroupByTagToEnabled: ko.Observable<boolean>;
     public readonly hyperlink: ko.Observable<HyperlinkModel>;
     public readonly hyperlinkTitle: ko.Computed<string>;
 
     constructor() {
         this.allowSelection = ko.observable(false);
+        this.defaultGroupByTagToEnabled = ko.observable(false);
         this.hyperlink = ko.observable();
         this.hyperlinkTitle = ko.computed<string>(
             () => this.hyperlink()
@@ -43,13 +45,16 @@ export class ListOfApisEditor {
     @OnMounted()
     public async initialize(): Promise<void> {
         this.allowSelection(this.model.allowSelection);
+        this.defaultGroupByTagToEnabled(this.model.defaultGroupByTagToEnabled);
         this.hyperlink(this.model.detailsPageHyperlink);
 
         this.allowSelection.subscribe(this.applyChanges);
+        this.defaultGroupByTagToEnabled.subscribe(this.applyChanges);        
     }
 
     private applyChanges(): void {
         this.model.allowSelection = this.allowSelection();
+        this.model.defaultGroupByTagToEnabled = this.defaultGroupByTagToEnabled();
         this.model.detailsPageHyperlink = this.hyperlink();
         this.onChange(this.model);
     }

--- a/src/components/apis/list-of-apis/ko/listOfApisViewModelBinder.ts
+++ b/src/components/apis/list-of-apis/ko/listOfApisViewModelBinder.ts
@@ -18,6 +18,7 @@ export class ListOfApisViewModelBinder implements ViewModelBinder<ListOfApisMode
 
         viewModel.runtimeConfig(JSON.stringify({
             allowSelection: model.allowSelection,
+            defaultGroupByTagToEnabled: model.defaultGroupByTagToEnabled,
             detailsPageUrl: model.detailsPageHyperlink
                 ? model.detailsPageHyperlink.href
                 : undefined

--- a/src/components/apis/list-of-apis/ko/runtime/api-list-tiles.ts
+++ b/src/components/apis/list-of-apis/ko/runtime/api-list-tiles.ts
@@ -45,16 +45,23 @@ export class ApiListTiles {
         this.hasPager = ko.computed(() => this.hasPrevPage() || this.hasNextPage());
         this.apiGroups = ko.observableArray();
         this.groupByTag = ko.observable(false);
+        this.defaultGroupByTagToEnabled = ko.observable(false);
     }
 
     @Param()
     public allowSelection: ko.Observable<boolean>;
 
     @Param()
+    public defaultGroupByTagToEnabled: ko.Observable<boolean>;
+
+    @Param()
     public detailsPageUrl: ko.Observable<string>;
 
     @OnMounted()
     public async initialize(): Promise<void> {
+
+        this.groupByTag(this.defaultGroupByTagToEnabled());
+
         await this.resetSearch();
 
         this.pattern

--- a/src/components/apis/list-of-apis/ko/runtime/api-list.ts
+++ b/src/components/apis/list-of-apis/ko/runtime/api-list.ts
@@ -41,16 +41,23 @@ export class ApiList {
         this.hasPager = ko.computed(() => this.hasPrevPage() || this.hasNextPage());
         this.apiGroups = ko.observableArray();
         this.groupByTag = ko.observable(false);
+        this.defaultGroupByTagToEnabled = ko.observable(false);
     }
 
     @Param()
     public allowSelection: ko.Observable<boolean>;
 
     @Param()
+    public defaultGroupByTagToEnabled: ko.Observable<boolean>;
+
+    @Param()
     public detailsPageUrl: ko.Observable<string>;
 
     @OnMounted()
     public async initialize(): Promise<void> {
+        
+        this.groupByTag(this.defaultGroupByTagToEnabled());
+
         await this.resetSearch();
 
         this.pattern

--- a/src/components/apis/list-of-apis/listOfApisContract.ts
+++ b/src/components/apis/list-of-apis/listOfApisContract.ts
@@ -17,6 +17,11 @@ export interface ListOfApisContract extends Contract {
     allowSelection: boolean;
 
     /**
+     * Default GroupByTag to enabled.
+     */
+    defaultGroupByTagToEnabled?: boolean;
+
+    /**
      * Link to a page that contains API details.
      */
     detailsPageHyperlink?: HyperlinkContract;

--- a/src/components/apis/list-of-apis/listOfApisModel.ts
+++ b/src/components/apis/list-of-apis/listOfApisModel.ts
@@ -12,6 +12,11 @@ export class ListOfApisModel {
     public allowSelection: boolean;
 
     /**
+     * Default GroupByTag to enabled.
+     */
+    public defaultGroupByTagToEnabled: boolean;
+
+    /**
      * Link to a page that contains operation details.
      */
     public detailsPageHyperlink: HyperlinkModel;

--- a/src/components/apis/list-of-apis/listOfApisModelBinder.ts
+++ b/src/components/apis/list-of-apis/listOfApisModelBinder.ts
@@ -17,6 +17,7 @@ export class ListOfApisModelBinder implements IModelBinder<ListOfApisModel> {
         
         model.layout = contract.itemStyleView;
         model.allowSelection = contract.allowSelection;
+        model.defaultGroupByTagToEnabled = contract.defaultGroupByTagToEnabled === true;
 
         if (contract.detailsPageHyperlink) {
             model.detailsPageHyperlink = await this.permalinkResolver.getHyperlinkFromConfig(contract.detailsPageHyperlink);
@@ -34,6 +35,7 @@ export class ListOfApisModelBinder implements IModelBinder<ListOfApisModel> {
             type: "listOfApis",
             itemStyleView: model.layout,
             allowSelection: model.allowSelection,
+            defaultGroupByTagToEnabled: model.defaultGroupByTagToEnabled,
             detailsPageHyperlink: model.detailsPageHyperlink
                 ? {
                     target: model.detailsPageHyperlink.target,


### PR DESCRIPTION
Feature enhancement to allow the group by tag toggle to be enabled by default on the list of APIs widget (both the List and Tile versions).

I've aimed to be consistent with PR #353 which added this functionality for the operations list