### PR TITLE
Improved support for nested object in schema.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -493,9 +493,9 @@
             }
         },
         "@webcomponents/custom-elements": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.4.0.tgz",
-            "integrity": "sha512-t9xpI4KVH4IcVp9XqLIAxHOovNcaUDDcfjK3v7ORv7xjnbIL1Dc+735tUTgyJvugTPAaxunILJY+Rh6+5729Hw=="
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.3.2.tgz",
+            "integrity": "sha512-0HtVxwE+PLPCIFL2i8/d+vjlrj8fgafmzZvIblZMyMcww9upicXTdfQT7K0Tg7tDlSoWxjmP2xKYP09A2YMocQ=="
         },
         "@webcomponents/shadydom": {
             "version": "1.7.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "@paperbits/core": "0.1.253",
         "@paperbits/prosemirror": "0.1.253",
         "@paperbits/styles": "0.1.253",
-        "@webcomponents/custom-elements": "^1.4.0",
+        "@webcomponents/custom-elements": "1.3.2",
         "@webcomponents/shadydom": "^1.7.2",
         "adal-vanilla": "^1.0.18",
         "applicationinsights-js": "^1.0.21",

--- a/src/components/operations/operation-details/ko/runtime/operation-details.html
+++ b/src/components/operations/operation-details/ko/runtime/operation-details.html
@@ -39,21 +39,21 @@
             <div class="table">
                 <div class="table-head">
                     <div class="table-row">
-                        <div class="col-3">Name</div>
+                        <div class="col-4">Name</div>
                         <div class="col-1">In</div>
                         <div class="col-1">Required</div>
-                        <div class="col-1">Type</div>
-                        <div class="col-6">Description</div>
+                        <div class="col-2">Type</div>
+                        <div class="col-4">Description</div>
                     </div>
                 </div>
                 <div class="table-body">
                     <!-- ko foreach: { data: operation().parameters, as: 'parameter' } -->
                     <div class="table-row">
-                        <div class="col-3" data-bind="text: parameter.name"></div>
+                        <div class="col-4 monospace" data-bind="text: parameter.name"></div>
                         <div class="col-1" data-bind="text: parameter.in"></div>
                         <div class="col-1" data-bind="text: parameter.required"></div>
-                        <div class="col-1" data-bind="text: parameter.type"></div>
-                        <div class="col-6" data-bind="markdown: parameter.description"></div>
+                        <div class="col-2 monospace" data-bind="text: parameter.type"></div>
+                        <div class="col-4" data-bind="markdown: parameter.description"></div>
                     </div>
                     <!-- /ko -->
                 </div>
@@ -65,19 +65,19 @@
             <div class="table">
                 <div class="table-head">
                     <div class="table-row">
-                        <div class="col-3">Name</div>
+                        <div class="col-4">Name</div>
                         <div class="col-1">Required</div>
-                        <div class="col-1">Type</div>
-                        <div class="col-7">Description</div>
+                        <div class="col-2">Type</div>
+                        <div class="col-4">Description</div>
                     </div>
                 </div>
                 <div class="table-body">
                     <!-- ko foreach: { data: operation().request.headers, as: 'header' } -->
                     <div class="table-row">
-                        <div class="col-3" data-bind="text: header.name"></div>
+                        <div class="col-4 monospace" data-bind="text: header.name"></div>
                         <div class="col-1" data-bind="text: header.required"></div>
-                        <div class="col-1" data-bind="text: header.type"></div>
-                        <div class="col-7" data-bind="markdown: header.description"></div>
+                        <div class="col-2 monospace" data-bind="text: header.type"></div>
+                        <div class="col-4" data-bind="markdown: header.description"></div>
                     </div>
                     <!-- /ko -->
                 </div>
@@ -157,8 +157,8 @@
     <div class="table">
         <div class="table-head">
             <div class="table-row">
-                <div class="col-3">Name</div>
-                <div class="col-9">Description</div>
+                <div class="col-4">Name</div>
+                <div class="col-8">Description</div>
             </div>
         </div>
         <div class="table-body">

--- a/src/components/operations/operation-details/ko/runtime/type-definition.html
+++ b/src/components/operations/operation-details/ko/runtime/type-definition.html
@@ -31,30 +31,54 @@
     <div class="table">
         <div class="table-head">
             <div class="table-row">
-                <div class="col-3">Name</div>
+                <div class="col-4">Name</div>
                 <div class="col-1">Required</div>
-                <div class="col-1">Type</div>
-                <div class="col-6">Description</div>
+                <div class="col-2">Type</div>
+                <div class="col-4">Description</div>
             </div>
         </div>
         <div class="table-body" data-bind="foreach: { data: definition.properties, as: 'property' }">
             <div class="table-row">
-                <div class="col-3 text-truncate">
-                    <code data-bind="text: property.name, attr: { title: property.name }"></code>
+                <div class="col-4 text-truncate" data-bind="text: property.name, attr: { title: property.name }">
+                    <span class="monospace" data-bind="text: property.name, attr: { title: property.name }"></span>
                 </div>
                 <div class="col-1" data-bind="text: property.required"></div>
-                <div class="col-1 text-truncate">
-                    <!-- ko if: property.type.isReference -->
-                    <a data-bind="text: property.type.name, attr: { href: $component.getReferenceUrl(property.type.name), title: property.type.name }"></a>
+                <div class="col-2 text-truncate">
+                    <!-- ko if: property.type.displayAs === 'primitive' -->
+                    <span class="monospace" data-bind="text: property.type.name, attr: { title: property.type.name }"></span>
                     <!-- /ko -->
-                    <!-- ko ifnot: property.type.isReference -->
-                    <code data-bind="text: property.type.name, attr: { title: property.type.name }"></code>
+
+                    <!-- ko if: property.type.displayAs === 'arrayOfPrimitive' -->
+                    <span class="monospace" data-bind="text: property.type.name, attr: { title: property.type.name }"></span>[]
                     <!-- /ko -->
-                    <!-- ko if: property.type.isArray -->
-                    []
+
+                    <!-- ko if: property.type.displayAs === 'reference' -->
+                    <a class="monospace" data-bind="text: property.type.name, attr: { href: $component.getReferenceUrl(property.type.name), title: property.type.name }"></a>
+                    <!-- /ko -->
+
+                    <!-- ko if: property.type.displayAs === 'arrayOfReference' -->
+                    <a class="monospace" data-bind="text: property.type.name, attr: { href: $component.getReferenceUrl(property.type.name), title: property.type.name }"></a>[]
+                    <!-- /ko -->
+
+                    <!-- ko if: property.type.displayAs === 'combination' -->
+                    <div>
+                        <span data-bind="text: property.type.combinationType"></span>:
+                    </div>
+                    <!-- ko foreach: { data: property.type.combination, as: 'item' } -->
+                    <!-- ko if: $index() > 0 -->,<!-- /ko -->
+                    <!-- ko if: item.displayAs === 'reference' -->
+                    <a class="monospace" data-bind="text: item.name, attr: { href: $component.getReferenceUrl(item.name), title: item.name }"></a>
+                    <!-- /ko -->
+
+                    <!-- ko if: item.displayAs === 'primitive' -->
+                    <span class="monospace" data-bind="text: item, attr: { title: item.name }"></span>
+                    <!-- /ko -->
+
+                    <!-- /ko -->
+
                     <!-- /ko -->
                 </div>
-                <div class="col-6" data-bind="markdown: property.description"></div>
+                <div class="col-4" data-bind="markdown: property.description"></div>
             </div>
         </div>
     </div>
@@ -70,17 +94,18 @@
     <div class="table">
         <div class="table-head">
             <div class="table-row">
-                <div class="col-1">Type</div>
-                <div class="col-11">Values</div>
+                <div class="col-2">Type</div>
+                <div class="col-10">Values</div>
             </div>
         </div>
         <div class="table-body">
             <div class="table-row">
-                <div class="col-1 text-truncate" data-bind="markdown: definition.type.name, attr: { title: definition.type.name }"></div>
-                <div class="col-11">
+                <div class="col-2 text-truncate"
+                    data-bind="markdown: definition.type.name, attr: { title: definition.type.name }"></div>
+                <div class="col-10">
                     <!-- ko foreach: { data: definition.enum, as: 'value' } -->
-                    <!-- ko if: $index() > 0 -->,
-                    <!-- /ko --><code data-bind="text: value"></code><!-- /ko -->
+                    <!-- ko if: $index() > 0 -->,<!-- /ko -->
+                    <code data-bind="text: value"></code><!-- /ko -->
                 </div>
             </div>
         </div>
@@ -91,25 +116,25 @@
     <div class="table">
         <div class="table-head">
             <div class="table-row">
-                <div class="col-3">Name</div>
+                <div class="col-4">Name</div>
                 <div class="col-2">Type</div>
-                <div class="col-7">Description</div>
+                <div class="col-6">Description</div>
             </div>
         </div>
         <div class="table-body" data-bind="foreach: { data: definition.properties, as: 'property' }">
             <div class="table-row">
-                <div class="col-3 text-truncate">
+                <div class="col-4 text-truncate">
                     <code data-bind="text: property.name, attr: { title: property.name }"></code>
                 </div>
                 <div class="col-2 text-truncate">
-                    <!-- ko if: property.type.isReference -->
-                    <a data-bind="text: property.type.name, attr: { href: $component.getReferenceUrl(property.type.name), attr: { title: property.type.name } }"></a>
+                    <!-- ko if: property.type.displayAs === 'reference' -->
+                    <code><a data-bind="text: property.type.name, attr: { href: $component.getReferenceUrl(property.type.name), attr: { title: property.type.name } }"></a></code>
                     <!-- /ko -->
-                    <!-- ko ifnot: property.type.isReference -->
+                    <!-- ko if: property.type.displayAs === 'primitive' -->
                     <code data-bind="text: property.type.name, attr: { title: property.type.name }"></code>
                     <!-- /ko -->
                 </div>
-                <div class="col-7" data-bind="markdown: property.description"></div>
+                <div class="col-6" data-bind="markdown: property.description"></div>
             </div>
         </div>
     </div>

--- a/src/contracts/schema.ts
+++ b/src/contracts/schema.ts
@@ -34,11 +34,13 @@ export interface SchemaObjectContract extends ReferenceObjectContract {
 
     items?: SchemaObjectContract;
 
-    allOf?: SchemaObjectContract;
+    allOf?: SchemaObjectContract[];
 
-    anyOf?: SchemaObjectContract;
+    anyOf?: SchemaObjectContract[];
 
-    not?: SchemaObjectContract;
+    oneOf?: SchemaObjectContract[];
+
+    not?: SchemaObjectContract[];
 
     minimum?: number;
 

--- a/src/models/typeDefinition.ts
+++ b/src/models/typeDefinition.ts
@@ -1,26 +1,45 @@
 import { SchemaObjectContract } from "../contracts/schema";
 
 
-export class TypeDefinitionPropertyType {
-    /**
-     * e.g. "string", "boolean", "object", etc.
-     */
-    public name: string;
+export abstract class TypeDefinitionPropertyType {
+    public displayAs: string;
 
-    /**
-     * Indicates if the type name inferred from reference ($ref: "#/definitions/Pet").
-     */
-    public isReference: boolean;
+    constructor(displayAs: string) {
+        this.displayAs = displayAs;
+    }
+}
 
-    /**
-     * Indicates if this is an array of the type.
-     */
-    public isArray: boolean;
 
-    constructor(name: string, isReference: boolean = false, isArray: boolean = false) {
-        this.name = name;
-        this.isReference = isReference;
-        this.isArray = isArray;
+export class TypeDefinitionPropertyTypePrimitive extends TypeDefinitionPropertyType {
+    constructor(public readonly name: string) {
+        super("primitive");
+    }
+}
+
+export class TypeDefinitionPropertyTypeReference extends TypeDefinitionPropertyType {
+    constructor(public readonly name: string) {
+        super("reference");
+    }
+}
+
+export class TypeDefinitionPropertyTypeArrayOfPrimitive extends TypeDefinitionPropertyType {
+    constructor(public readonly name: string) {
+        super("arrayOfPrimitive");
+    }
+}
+
+export class TypeDefinitionPropertyTypeArrayOfReference extends TypeDefinitionPropertyType {
+    constructor(public name: string) {
+        super("arrayOfReference");
+    }
+}
+
+export class TypeDefinitionPropertyTypeCombination extends TypeDefinitionPropertyType {
+    constructor(
+        public readonly combinationType: string,
+        public readonly combination: TypeDefinitionPropertyType[]
+    ) {
+        super("combination");
     }
 }
 
@@ -74,7 +93,7 @@ export abstract class TypeDefinitionProperty {
     constructor(name: string, contract: SchemaObjectContract, isRequired: boolean, isArray: boolean) {
         this.name = contract.title || name;
         this.description = contract.description;
-        this.type = new TypeDefinitionPropertyType(contract.format || contract.type || "object");
+        this.type = new TypeDefinitionPropertyTypePrimitive(contract.format || contract.type || "object");
         this.isArray = isArray;
 
         if (contract.example) {
@@ -103,7 +122,45 @@ export class TypeDefinitionEnumerationProperty extends TypeDefinitionProperty {
         super(name, contract, isRequired, isArray);
 
         this.kind = "enum";
-        this.enum = this.enum;
+    }
+}
+
+export class TypeDefinitionCombinationProperty extends TypeDefinitionProperty {
+    constructor(name: string, contract: SchemaObjectContract, isRequired: boolean) {
+        super(name, contract, isRequired, false);
+
+        let combinationType;
+        let combinationArray;
+
+        if (contract.allOf) {
+            combinationType = "All of";
+            combinationArray = contract.allOf;
+        }
+
+        if (contract.anyOf) {
+            combinationType = "Any of";
+            combinationArray = contract.anyOf;
+        }
+
+        if (contract.oneOf) {
+            combinationType = "One of";
+            combinationArray = contract.oneOf;
+        }
+
+        if (contract.not) {
+            combinationType = "Not";
+            combinationArray = contract.not;
+        }
+
+        const combination = combinationArray.map(item => {
+            if (item.$ref) {
+                return new TypeDefinitionPropertyTypeReference(getTypeNameFromRef(item.$ref));
+            }
+            return new TypeDefinitionPropertyTypePrimitive(item.type || "object");
+        });
+
+        this.type = new TypeDefinitionPropertyTypeCombination(combinationType, combination);
+        this.kind = "combination";
     }
 }
 
@@ -113,25 +170,25 @@ export class TypeDefinitionObjectProperty extends TypeDefinitionProperty {
      */
     public properties?: TypeDefinitionProperty[];
 
-    constructor(name: string, contract: SchemaObjectContract, isRequired: boolean, isArray: boolean = false) {
+    constructor(name: string, contract: SchemaObjectContract, isRequired: boolean, isArray: boolean = false, nested: boolean = false) {
         super(name, contract, isRequired, isArray);
 
         this.kind = "object";
 
         if (contract.$ref) { // reference
-            this.type = new TypeDefinitionPropertyType(this.getTypeNameFromRef(contract.$ref), true);
+            this.type = new TypeDefinitionPropertyTypeReference(getTypeNameFromRef(contract.$ref));
             return;
         }
 
         if (contract.items) { // indexer
-            let type = new TypeDefinitionPropertyType("object");
+            let type = new TypeDefinitionPropertyTypePrimitive("object");
 
             if (contract.items.type) {
-                type = new TypeDefinitionPropertyType(contract.items.type);
+                type = new TypeDefinitionPropertyTypePrimitive(contract.items.type);
             }
 
             if (contract.items.$ref) {
-                type = new TypeDefinitionPropertyType(this.getTypeNameFromRef(contract.items.$ref), true);
+                type = new TypeDefinitionPropertyTypeReference(getTypeNameFromRef(contract.items.$ref));
             }
 
             this.properties = [new TypeDefinitionIndexerProperty(type)];
@@ -145,71 +202,122 @@ export class TypeDefinitionObjectProperty extends TypeDefinitionProperty {
         }
 
         if (contract.properties) { // complex type
-            this.properties = Object
+            const props = [];
+
+            Object
                 .keys(contract.properties)
-                .map(propertyName => {
-                    const propertySchemaObject = contract.properties[propertyName];
+                .forEach(propertyName => {
+                    try {
+                        const propertySchemaObject = contract.properties[propertyName];
 
-                    if (!propertySchemaObject) {
-                        return null;
+                        if (!propertySchemaObject) {
+                            return;
+                        }
+
+                        const isRequired = contract.required?.includes(propertyName) || false;
+
+                        if (propertySchemaObject.$ref) {
+                            propertySchemaObject.type = "object";
+                        }
+
+                        if (propertySchemaObject.items) {
+                            propertySchemaObject.type = "array";
+                        }
+
+                        if (propertySchemaObject.allOf ||
+                            propertySchemaObject.anyOf ||
+                            propertySchemaObject.oneOf ||
+                            propertySchemaObject.not
+                        ) {
+                            propertySchemaObject.type = "combination";
+                        }
+
+                        switch (propertySchemaObject.type) {
+                            case "integer":
+                            case "number":
+                            case "string":
+                            case "boolean":
+                                if (propertySchemaObject.enum) {
+                                    props.push(new TypeDefinitionEnumerationProperty(propertyName, propertySchemaObject, isRequired));
+                                }
+
+                                props.push(new TypeDefinitionPrimitiveProperty(propertyName, propertySchemaObject, isRequired));
+                                break;
+
+                            case "object":
+                                const objectProperty = new TypeDefinitionObjectProperty(propertyName, propertySchemaObject, isRequired, true, true);
+
+                                if (!nested) {
+                                    const flattenObjects = this.flattenNestedObjects(objectProperty, propertyName);
+                                    props.push(...flattenObjects);
+                                }
+                                else {
+                                    props.push(objectProperty);
+                                }
+
+                                break;
+
+                            case "array":
+                                const arrayProperty = new TypeDefinitionPrimitiveProperty(propertyName, propertySchemaObject, isRequired, true);
+
+                                if (!propertySchemaObject.items) {
+                                    return arrayProperty;
+                                }
+
+                                if (propertySchemaObject.items.$ref) {
+                                    arrayProperty.type = new TypeDefinitionPropertyTypeArrayOfReference(getTypeNameFromRef(propertySchemaObject.items.$ref));
+                                }
+                                else if (propertySchemaObject.items.type) {
+                                    arrayProperty.type = new TypeDefinitionPropertyTypeArrayOfPrimitive(propertySchemaObject.items.type);
+                                }
+                                else {
+                                    const objectProperty = new TypeDefinitionObjectProperty(propertyName + "[]", propertySchemaObject.items, isRequired, true, true);
+                                    props.push(objectProperty);
+                                }
+
+                                props.push(arrayProperty);
+                                break;
+
+                            case "combination":
+                                props.push(new TypeDefinitionCombinationProperty(propertyName, propertySchemaObject, isRequired));
+                                break;
+
+                            default:
+                                console.warn(`Unknown type of schema definition: ${propertySchemaObject.type}`);
+                        }
                     }
-
-                    const isRequired = contract.required?.includes(propertyName) || false;
-
-                    if (propertySchemaObject.$ref) {
-                        propertySchemaObject.type = "object";
+                    catch (error) {
+                        console.warn(`Unable to process object property ${propertyName}. Error: ${error}`);
                     }
+                });
 
-                    if (propertySchemaObject.items) {
-                        propertySchemaObject.type = "array";
-                    }
-
-                    switch (propertySchemaObject.type) {
-                        case "integer":
-                        case "number":
-                        case "string":
-                        case "boolean":
-                            if (propertySchemaObject.enum) {
-                                return new TypeDefinitionEnumerationProperty(propertyName, propertySchemaObject, isRequired);
-                            }
-
-                            return new TypeDefinitionPrimitiveProperty(propertyName, propertySchemaObject, isRequired);
-                            break;
-
-                        case "object":
-                            return new TypeDefinitionObjectProperty(propertyName, propertySchemaObject, isRequired, true);
-                            break;
-
-                        case "array":
-                            const prop = new TypeDefinitionPrimitiveProperty(propertyName, propertySchemaObject, isRequired, true);
-
-                            if (!propertySchemaObject.items) {
-                                return prop;
-                            }
-
-                            if (propertySchemaObject.items.type) {
-                                prop.type = new TypeDefinitionPropertyType(propertySchemaObject.items.type, false, true);
-                            }
-
-                            if (propertySchemaObject.items.$ref) {
-                                prop.type = new TypeDefinitionPropertyType(this.getTypeNameFromRef(propertySchemaObject.items.$ref), true, true);
-                            }
-
-                            return prop;
-
-                            break;
-
-                        default:
-                            console.warn(`Unknown type of schema definition: ${propertySchemaObject.type}`);
-                    }
-                })
-                .filter(x => !!x);
+            this.properties = props;
         }
     }
 
-    protected getTypeNameFromRef($ref: string): string {
-        return $ref && $ref.split("/").pop();
+    private flattenNestedObjects(nested: TypeDefinitionProperty, prefix: string): TypeDefinitionProperty[] {
+        const result = [];
+
+        if (!nested["properties"]) {
+            return result;
+        }
+
+        nested["properties"].forEach(property => {
+            if (property instanceof TypeDefinitionObjectProperty) {
+                result.push(...this.flattenNestedObjects(<TypeDefinitionObjectProperty>property, prefix + "." + property.name));
+            }
+            else {
+                property.name = prefix + "." + property.name;
+                result.push(property);
+            }
+        });
+
+        return result;
     }
+}
+
+function getTypeNameFromRef($ref: string): string {
+    return $ref && $ref.split("/").pop();
 }
 
 export class TypeDefinitionIndexerProperty extends TypeDefinitionObjectProperty {

--- a/src/startup.runtime.ts
+++ b/src/startup.runtime.ts
@@ -2,16 +2,17 @@ import { InversifyInjector } from "@paperbits/common/injection";
 import { ApimRuntimeModule } from "./apim.runtime.module";
 import { HistoryRouteHandler, LocationRouteHandler } from "@paperbits/common/routing";
 
+
+const injector = new InversifyInjector();
+injector.bindModule(new ApimRuntimeModule());
+
+if (location.href.includes("designtime=true")) {
+    injector.bindToCollection("autostart", HistoryRouteHandler);
+}
+else {
+    injector.bindToCollection("autostart", LocationRouteHandler);
+}
+
 document.addEventListener("DOMContentLoaded", () => {
-    const injector = new InversifyInjector();
-    injector.bindModule(new ApimRuntimeModule());
-
-    if (location.href.includes("designtime=true")) {
-        injector.bindToCollection("autostart", HistoryRouteHandler);
-    }
-    else {
-        injector.bindToCollection("autostart", LocationRouteHandler);
-    }
-
     injector.resolve("autostart");
 });

--- a/src/themes/website/styles/utils.scss
+++ b/src/themes/website/styles/utils.scss
@@ -23,3 +23,8 @@
 .d-block {
     display: block;
 }
+
+.text-truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}


### PR DESCRIPTION
This commit addresses a number of requests for rendering nested schema objects. For example, schema object like this...

```json
{
    "type": "object",
    "properties": {
        "employee": {
            "type": "object",
            "properties": {
                "firstName": {
                    "type": "string"
                },
                "lastName": {
                    "type": "string"
                },
                "address": {
                    "type": "object",
                    "properties": {
                        "city": {
                            "type": "string"
                        },
                        "state": {
                            "type": "string"
                        },
                        "street": {
                            "type": "string"
                        }
                    }
                }
            }
        },
        "dealer": {
            "allOf": [
                {
                    "$ref": "#/components/employee"
                },
                {
                    "$ref": "#/components/manager"
                }
            ]
        }
    },
    "additionalProperties": false
}
```
...results into the following representation:
![image](https://user-images.githubusercontent.com/2320302/79400735-e6312580-7f3b-11ea-8f86-dad70843110f.png)
Closing #522. 