### PR TITLE
Double slashes shown in Developer Portal Doc

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/operation-details.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-details.ts
@@ -63,12 +63,12 @@ export class OperationDetails {
             const apiPath = api.versionedPath;
 
             if (api.type === TypeOfApi.soap) {
-                return `https://${hostname}/${apiPath}`;
+                return `https://${hostname}${apiPath}`;
             }
 
             const operationPath = operation.displayUrlTemplate;
 
-            return `https://${hostname}/${apiPath}${operationPath}`;
+            return `https://${hostname}${apiPath}${operationPath}`;
         });
     }
 


### PR DESCRIPTION
The extra "/" was causing that the Url sample show double slashes on our Protal Developer documentation like this: