### PR TITLE
Move ProseMirror design-time css

### DIFF
--- a/src/themes/designer/styles/widgets.scss
+++ b/src/themes/designer/styles/widgets.scss
@@ -1,5 +1,6 @@
 ﻿@import "widgets/map.scss";
 @import "widgets/video.scss";
+@import "widgets/textblock.scss";
 @import "editors/videoEditor.scss";
 @import "editors/rowLayoutSelector.scss";
 @import "editors/colorSelector.scss";

--- a/src/themes/designer/styles/widgets/textblock.scss
+++ b/src/themes/designer/styles/widgets/textblock.scss
@@ -1,0 +1,21 @@
+[contenteditable]:focus {
+    outline: none;
+}
+
+.ProseMirror {
+    position: relative;
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    white-space: break-spaces;
+    -webkit-font-variant-ligatures: none;
+    font-variant-ligatures: none;
+    font-feature-settings: "liga" 0; /* the above doesn't seem to work in Edge */
+
+    pre {
+        white-space: pre-wrap;
+    }
+
+    li {
+        position: relative;
+    }
+}

--- a/src/themes/website/styles/widgets/textblock.scss
+++ b/src/themes/website/styles/widgets/textblock.scss
@@ -1,27 +1,5 @@
-[contenteditable]:focus {
-    outline: none;
-}
-
 p:empty {
     &:before {
         content: " ";
-    }
-}
-
-.ProseMirror {
-    position: relative;
-    word-wrap: break-word;
-    white-space: pre-wrap;
-    white-space: break-spaces;
-    -webkit-font-variant-ligatures: none;
-    font-variant-ligatures: none;
-    font-feature-settings: "liga" 0; /* the above doesn't seem to work in Edge */
-
-    pre {
-        white-space: pre-wrap;
-    }
-
-    li {
-        position: relative;
     }
 }


### PR DESCRIPTION
> NOTE: Updated the pull request, see further comments below
I'm not sure why these white-space properties are necessary.  I've had a go at removing them and none of the styling seems to break.

The reason I suggest removing them is that although it works fine when the published html is condensed onto a single line, if you format the document in a code editor, the styling breaks.

I came across the issue when trying to make adjustments to the html after the site has been published.