### PR TITLE
Fix publish website "not found" error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ For **assistance requests**, submit a post [on Stack Overflow](http://aka.ms/api
 
 We welcome and appreciate **[community contributions](CONTRIBUTIONS.md)**. Refer to the **[contribution guidelines](https://github.com/Azure/api-management-developer-portal/wiki/Widget-contribution-guidelines)** for more information.
 
+##<a name="fix"></a> Fix Publish from localhost designer mode
+When opening localhost designer and trying to publish you may get CORS error: 
+Access to XMLHttpRequest at 'https://apimboris.developer.azure-api.net/publish' from origin 'http://localhost:8080' has been blocked by CORS policy: Request header field authorization is not allowed by Access-Control-Allow-Headers in preflight response.
+
+One way to solve this error while publishing from localhost:8080 is to disable CORS by passing parameters to Chrome via command line. For example, run the following command as administrator:
+```
+"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --disable-web-security --disable-gpu --user-data-dir=c:\users\cors-off
+```
+
 ## <a name="license"></a> License
 
 The developer portal is based on our own fork of the [Paperbits framework](http://paperbits.io/), which we enriched with API Management-specific features, and is published under [MIT license](license).

--- a/README.md
+++ b/README.md
@@ -20,15 +20,6 @@ For **assistance requests**, submit a post [on Stack Overflow](http://aka.ms/api
 
 We welcome and appreciate **[community contributions](CONTRIBUTIONS.md)**. Refer to the **[contribution guidelines](https://github.com/Azure/api-management-developer-portal/wiki/Widget-contribution-guidelines)** for more information.
 
-##<a name="fix"></a> Fix Publish from localhost designer mode
-When opening localhost designer and trying to publish you may get CORS error: 
-Access to XMLHttpRequest at 'https://apimboris.developer.azure-api.net/publish' from origin 'http://localhost:8080' has been blocked by CORS policy: Request header field authorization is not allowed by Access-Control-Allow-Headers in preflight response.
-
-One way to solve this error while publishing from localhost:8080 is to disable CORS by passing parameters to Chrome via command line. For example, run the following command as administrator:
-```
-"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --disable-web-security --disable-gpu --user-data-dir=c:\users\cors-off
-```
-
 ## <a name="license"></a> License
 
 The developer portal is based on our own fork of the [Paperbits framework](http://paperbits.io/), which we enriched with API Management-specific features, and is published under [MIT license](license).

--- a/src/components/content/content.ts
+++ b/src/components/content/content.ts
@@ -6,20 +6,23 @@ import { Logger } from "@paperbits/common/logging";
 import { IAuthenticator } from "../../authentication/IAuthenticator";
 import { AppError } from "./../../errors/appError";
 import { MapiError } from "../../errors/mapiError";
-
+import { ISettingsProvider } from "@paperbits/common/configuration";
 
 @Component({
     selector: "content-workshop",
     template: template
 })
+
 export class ContentWorkshop {
     constructor(
         private readonly viewManager: ViewManager,
         private readonly httpClient: HttpClient,
         private readonly authenticator: IAuthenticator,
+        private readonly settingsProvider: ISettingsProvider,
         private readonly logger: Logger
     ) {
-        this.viewManager = viewManager;
+		this.viewManager = viewManager;
+		alert("content constructor - OK")
     }
 
     public async publish(): Promise<void> {
@@ -30,10 +33,11 @@ export class ContentWorkshop {
         }
 
         try {
-            const accessToken = await this.authenticator.getAccessToken();
+			const accessToken = await this.authenticator.getAccessToken();
 
+			const publishRootUrl = await this.settingsProvider.getSetting<string>("backendUrl"); 
             const response = await this.httpClient.send({
-                url: "/publish",
+                url: publishRootUrl + "/publish",
                 method: "POST",
                 headers: [{ name: "Authorization", value: accessToken }]
             });


### PR DESCRIPTION
…by doing publish to the APIM backend URL. GitHub issue: Posting to /publish endpoint results in Resource not found. #826

I also updated the Readme file because this fixed version causes CORS error. I could not find a way to configure CORS for the publish method to work, so I temporarily disable CORS for publishing developer portal. 