### PR TITLE
Added files for backing up and restoring the portal

### DIFF
--- a/scripts/backup.js
+++ b/scripts/backup.js
@@ -1,0 +1,169 @@
+"use strict"
+/**
+ * This script saves the developer portal instance.
+ * In order to run it, you need to:
+ * 
+ * 1) Clone the api-management-developer-portal repository
+ * 2) `npm install` in the root of the project
+ * 3) Install az-cli (https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+ * 4) Run this script with a valid combination of arguments
+ * 
+ * Managed portal command example:
+ * node backup --sourceEndpoint from.management.azure-api.net --publishEndpoint to.developer.azure-api.net --sourceToken "SharedAccessSignature integration&2020..."  --dataFile d:\apim-portal\great.json --mediaFolder d:\apim-portal\great\
+ * 
+ * If you run with the --selfHosted flag, you are expected to supply a sourceStorage parameter.
+ * 
+ * You can specify the SAS tokens directly (via sourceToken), or you can supply an identifier and key,
+ * and the script will generate tokens that expire in 1 hour. (via sourceId, sourceKey).
+ */
+
+const path = require("path");
+const mkdirSync = require('fs').mkdirSync;
+const execSync = require('child_process').execSync;
+
+const shared = require('./shared');
+
+const yargs = require('yargs')
+.version('1.0.2')
+    .example('$0 \
+        --sourceEndpoint contoso.management.azure-api.net \
+        --sourceToken <token> \
+        --dataFile d:\apim-portal\contoso.json \
+        --mediaFolder d:\apim-portal\contoso \n')
+    .example('$0 \
+        --sourceEndpoint great.management.azure-api.net \
+        --sourceId integration \
+        --sourceKey Sshbh493lagtssTH3902kdfksjslqa65saa239hJKdjaWtmmnssPhcCthhcEisagaYyalLalaTWMwuqcosa7sv== \
+        --dataFile d:\apim-portal\great.json \
+        --mediaFolder d:\apim-portal\great\
+        --addTimestamp\n')
+    .example('$0 --selfHosted \
+        --sourceEndpoint halibut.management.azure-api.net> \
+        --sourceToken <token> \
+        --sourceStorage <connectionString>\
+        --dataFile d:\apim-portal\halibut\data.json \
+        --mediaFolder d:\apim-portal\halibut\media\n')
+    .option('selfHosted', {
+        alias: 'h',
+        type: 'boolean',
+        description: 'If the portal is self-hosted',
+        implies: 'sourceStorage'
+    })
+    .option('addTimestamp', {
+        type: 'boolean',
+        description: 'Adds a timestamp to the data file name and the media folder name'
+    })
+    .option('sourceEndpoint', {
+        type: 'string',
+        description: 'The hostname of the management endpoint of the source API Management service',
+        example: 'name.management.azure-api.net',
+        demandOption: true
+    })
+    .option('sourceId', {
+        type: 'string',
+        description: 'The management API identifier',
+        implies: 'sourceKey',
+        conflicts: 'sourceToken'
+    })
+    .option('sourceKey', {
+        type: 'string',
+        description: 'The management API key (primary or secondary)',
+        implies: 'sourceId',
+        conflicts: 'sourceToken'
+    })
+    .option('sourceToken', {
+        type: 'string',
+        description: 'A SAS token for the source portal',
+        example: 'SharedAccessSignature…',
+        conflicts: ['sourceId, sourceToken']
+    })
+    .option('sourceStorage', {
+        type: 'string',
+        description: 'The connection string for self-hosted portals',
+        example: 'DefaultEndpointsProtocol=…',
+        implies: 'selfHosted'
+    })
+    .option('dataFile', {
+        type: 'string',
+        description: 'The path to the file which will store the content of the portal except the media files',
+        example: '..\dist\data.json',
+        demandOption: 'true'
+    })
+    .option('mediaFolder', {
+        type: 'string',
+        description: 'The path to the folder which will store the media content of the portal',
+        example: '..\dist\content',
+        demandOption: 'true'
+    })
+    .argv;
+
+async function run() {
+    const sourceEndpoint = yargs.sourceEndpoint;
+    const sourceToken = await shared.getTokenOrThrow(yargs.sourceToken, yargs.sourceId, yargs.sourceKey);
+    const sourceStorage = await shared.getStorageConnectionOrThrow(yargs.sourceStorage, sourceEndpoint, sourceToken);
+    const dataFile = yargs.dataFile;
+    var mediaFolder = yargs.mediaFolder;
+    
+    const mediaContainer = 'content';
+
+    console.log(`Starting backup of ${sourceEndpoint}.`);
+
+    // capture the content of the source portal (excl. media)
+    var absoluteFilePath = path.resolve(dataFile);
+    const dataFileFolder = path.parse(absoluteFilePath).dir;
+
+    // add the time
+    if(yargs.addTimestamp){ 
+        const timestamp = new Date();
+        const postfix = "-" +
+            timestamp.getFullYear() +
+            makeTwo(timestamp.getMonth() + 1) +
+            makeTwo(timestamp.getDate()) +
+            makeTwo(timestamp.getHours()) +
+            makeTwo(timestamp.getMinutes()) +
+            makeTwo(timestamp.getSeconds());
+
+        absoluteFilePath = path.format({
+            dir: dataFileFolder,
+            name: path.parse(absoluteFilePath).name + postfix,
+            ext: path.parse(absoluteFilePath).ext
+        });
+
+        mediaFolder += postfix;
+    }
+
+    // make sure the folders are created before writing to them
+    mkdirSync(dataFileFolder, {recursive: true});
+    mkdirSync(mediaFolder, { recursive: true });
+
+    // create the data file
+    console.log(`Capturing portal customizations except media to ${absoluteFilePath}.`);
+    execSync(`node ./capture "${sourceEndpoint}" "${sourceToken}" "${absoluteFilePath}"`);
+
+    // download media files from the source portal
+    const absoluteMediaFolder = path.resolve(mediaFolder);
+    console.log(`Saving media files to  ${absoluteMediaFolder}.`);
+    execSync(`az storage blob download-batch\
+        --source "${mediaContainer}"\
+        --destination "${absoluteMediaFolder}"\
+        --connection-string "${sourceStorage}"`);
+
+    console.log(`The backup operation of ${sourceEndpoint} is finished.`);
+}
+
+function makeTwo(digits) {
+    const asString = digits.toString();
+
+    if(asString.length == 0) {
+        return "00";
+    }
+
+    if (asString.length == 1) {
+        return "0" + asString;
+    }
+
+    return asString.slice(-2);
+}
+
+
+run();

--- a/scripts/restore.js
+++ b/scripts/restore.js
@@ -1,0 +1,154 @@
+"use strict"
+/**
+ * This script applies deployments to a developer portal instance.
+ * In order to run it, you need to:
+ * 
+ * 1) Clone the api-management-developer-portal repository
+ * 2) `npm install` in the root of the project
+ * 3) Install az-cli (https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+ * 4) Run this script with a valid combination of arguments
+ * 
+ * Managed portal command example:
+ * node restore --destEndpoint to.management.azure-api.net --publishEndpoint to.developer.azure-api.net --destToken "SharedAccessSignature integration&2020..."   --dataFile d:\apim-portal\great.json --mediaFolder d:\apim-portal\great\
+ * 
+ * If you run with the --selfHosted flag, you are expected to supply a destStorage parameter.
+ * Auto-publishing is not supported for self-hosted versions, so make sure you publish the portal (for example, locally) and upload the generated static files to your hosting after the migration is completed.
+ * 
+ * You can specify the SAS tokens directly (via destToken), or you can supply an identifier and key,
+ * and the script will generate tokens that expire in 1 hour. (via destId, destKey)
+ */
+
+const path = require("path");
+const execSync = require('child_process').execSync;
+
+const shared = require('./shared');
+
+const yargs = require('yargs')
+    .version('1.0.2')
+    .example('$0 \
+        --publishEndpoint <name.management.azure-api.net> \
+        --destEndpoint <name.management.azure-api.net> \
+        --destToken <token> \
+        --dataFile <filePath> \
+        --mediaFolder <folderPath>\n')
+    .example('$0 --selfHosted \
+        --destEndpoint <name.management.azure-api.net> \
+        --destToken <token> \
+        --destStorage <connectionString>\
+        --dataFile <filePath> \
+        --mediaFolder <folderPath>\n')
+    .option('selfHosted', {
+        alias: 'h',
+        type: 'boolean',
+        description: 'If the portal is self-hosted',
+        implies: 'destStorage'
+    })
+    .option('publishEndpoint', {
+        alias: 'p',
+        type: 'string',
+        description: 'Endpoint of the destination managed developer portal; if empty, destination portal will not be published; unsupported in self-hosted scenario',
+        example: '<name.developer.azure-api.net>'
+    })
+    .option('destEndpoint', {
+        type: 'string',
+        description: 'The hostname of the management endpoint of the destination API Management service',
+        example: '<name.management.azure-api.net>',
+        demandOption: true
+    })
+    .option('destId', {
+        type: 'string',
+        description: 'The management API identifier',
+        implies: 'destKey',
+        conflicts: 'destToken'
+    })
+    .option('destKey', {
+        type: 'string',
+        description: 'The management API key (primary or secondary)',
+        implies: 'destId',
+        conflicts: 'destToken'
+    })
+    .option('destToken', {
+        type: 'string',
+        example: 'SharedAccessSignature…',
+        description: 'A SAS token for the destination portal',
+        conflicts: ['destId, destToken']
+    })
+    .option('destStorage', {
+        type: 'string',
+        description: 'The connection string for self-hosted portals',
+        example: 'DefaultEndpointsProtocol=…',
+        implies: 'selfHosted'
+    })
+    .option('dataFile', {
+        type: 'string',
+        description: 'The path to the file which contains the content of the portal except the media files',
+        example: '..\dist\data.json',
+        demandOption: true
+    })
+    .option('mediaFolder', {
+        type: 'string',
+        description: 'The path to the folder which contains the media content of the portal',
+        example: '..\dist\content',
+        demandOption: true
+    })
+    .argv;
+
+async function run() {
+    const destEndpoint = yargs.destEndpoint;
+    const destToken = await shared.getTokenOrThrow(yargs.destToken, yargs.destId, yargs.destKey);
+    const destStorage = await shared.getStorageConnectionOrThrow(yargs.destStorage, destEndpoint, destToken);
+    const dataFile = yargs.dataFile;
+    const mediaFolder = yargs.mediaFolder;
+    const publishEndpoint = yargs.publishEndpoint;
+    
+    const mediaContainer = 'content';
+    
+    console.log(`Starting restore to ${destEndpoint}.`);
+
+    // remove all content of the target portal (incl. media)
+    console.log(`Removing all content at ${destEndpoint}.`);
+    execSync(`node ./cleanup ${destEndpoint} "${destToken}" "${destStorage}"`);
+
+    // upload the content of the source portal (excl. media)
+    console.log(`Applying data from ${dataFile} to ${destEndpoint}.`);
+    execSync(`node ./generate ${destEndpoint} "${destToken}" ${dataFile}`);
+
+    // upload media files to the target portal
+    console.log(`Uploading media files from ${mediaFolder} to ${destStorage}.`);
+    execSync(`az storage blob upload-batch\
+        --source "${mediaFolder}"\
+        --destination "${mediaContainer}"\
+        --connection-string "${destStorage}"`);
+
+    if (publishEndpoint && !yargs.selfHosted) {
+        console.log(`Pulishing portal at ${publishEndpoint}.`);
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+        publish(publishEndpoint, destToken);
+    } else if (publishEndpoint) {
+        console.warn("Auto-publishing self-hosted portal is not supported.");
+    }
+
+    console.log(`The restore operation to ${destEndpoint} is finished.`);
+}
+
+/**
+ * Publishes the content of the specified APIM instance using a SAS token.
+ * @param {string} endpoint the publishing endpoint of the destination developer portal instance
+ * @param {string} token the SAS token
+ */
+async function publish(endpoint, token) {
+    const options = {
+        port: 443,
+        method: 'POST',
+        headers: {
+            'Authorization': token
+        }
+    };
+    
+    const url = `https://${endpoint}/publish`;
+    
+    // returns with literal OK (missing quotes), which is invalid json.
+    await shared.request(url, options);
+}
+
+run();

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -1,0 +1,120 @@
+"use strict"
+/**
+ * This script contains functions used by backup.js and restore.js. It is copied from migrate.js.
+ */
+
+const https = require('https');
+const moment = require('moment');
+const crypto = require('crypto');
+
+module.exports.request = request;
+module.exports.getTokenOrThrow = getTokenOrThrow;
+module.exports.getStorageConnectionOrThrow = getStorageConnectionOrThrow;
+
+/**
+ * Attempts to get a SAS token in two ways:
+ * 1) if the token is explicitly set by the user, use that token.
+ * 2) if the id and key are specified, manually generate a SAS token.
+ * @param {string} token an optionally specified token
+ * @param {string} id the Management API identifier
+ * @param {string} key the Management API key
+ */
+async function getTokenOrThrow(token, id, key) {
+    if (token) {
+        return token;
+    }
+    if (id && key) {
+        return await generateSASToken(id, key);
+    }
+    throw Error('You need to specify either: token or id AND key');
+}
+
+/**
+* Attempts to get a develoer portal storage connection string in two ways:
+* 1) if the connection string is explicitly set by the user, use it.
+* 2) retrieving the connection string from the management API using the instance endpoint and SAS token
+* @param {string} storage an optionally specified storage connection string
+* @param {string} endpoint the management endpoint of service instance
+* @param {string} token the SAS token
+*/
+async function getStorageConnectionOrThrow(storage, endpoint, token) {
+    if (storage) {
+        return storage;
+    }
+    if (token) {
+        // token should always be available, because we call
+        // getTokenOrThrow before this
+        return await getStorageConnection(endpoint, token);
+    }
+    throw Error('Storage connection could not be retrieved');
+}
+
+/**
+ * A wrapper for making a request and returning its response body.
+ * @param {Object} options https options
+ */
+async function request(url, options) {
+    return new Promise((resolve, reject) => {
+        const req = https.request(url, options, (resp) => {
+            let data = '';
+
+            resp.on('data', (chunk) => {
+                data += chunk;
+            });
+
+            resp.on('end', () => {
+                try {
+                    resolve(data);
+                }
+                catch (e) {
+                    reject(e);
+                }
+            });
+        });
+
+        req.on('error', (e) => {
+            reject(e);
+        });
+
+        req.end();
+    });
+}
+
+/**
+ * Generates a SAS token from the specified Management API id and key.  Optionally
+ * specify the expiry time, in seconds.
+ * 
+ * See https://docs.microsoft.com/en-us/rest/api/apimanagement/apimanagementrest/azure-api-management-rest-api-authentication#ManuallyCreateToken
+ * @param {string} id The Management API identifier.
+ * @param {string} key The Management API key (primary or secondary)
+ * @param {number} expiresIn The number of seconds in which the token should expire.
+ */
+async function generateSASToken(id, key, expiresIn = 3600) {
+    const now = moment.utc(moment());
+    const expiry = now.clone().add(expiresIn, 'seconds');
+    const expiryString = expiry.format(`YYYY-MM-DD[T]HH:mm:ss.SSSSSSS[Z]`);
+
+    const dataToSign = `${id}\n${expiryString}`;
+    const signedData = crypto.createHmac('sha512', key).update(dataToSign).digest('base64');
+    return `SharedAccessSignature uid=${id}&ex=${expiryString}&sn=${signedData}`;
+}
+
+/**
+ * Gets a storage connection string from the management API for the specified APIM instance and
+ * SAS token.
+ * @param {string} endpoint the management endpoint of service instance
+ * @param {string} token the SAS token
+ */
+async function getStorageConnection(endpoint, token) {
+    const options = {
+        port: 443,
+        method: 'GET',
+        headers: {
+            'Authorization': token
+        }
+    };
+
+    const raw = await request(`https://${endpoint}/tenant/settings?api-version=2018-01-01`, options);
+    const body = JSON.parse(raw);
+    return body.settings.PortalStorageConnectionString;
+}


### PR DESCRIPTION
This would fix #848 

Most of the code is copied from migrate.js. To remove the duplicated code, migrate.js could use the functions in shared.js.  
