### PR TITLE
Added soap badge for product APIs

### DIFF
--- a/src/components/products/product-apis/ko/runtime/product-apis.html
+++ b/src/components/products/product-apis/ko/runtime/product-apis.html
@@ -30,6 +30,9 @@
             <div class="col-5">
                 <a href="#" class="text-truncate" data-bind="attr: { href: $component.getReferenceUrl(item) }">
                     <span data-bind="text: item.displayName"></span>
+                    <!-- ko if: item.type === 'soap' -->
+                    <span class="badge badge-soap">SOAP</span>
+                    <!-- /ko -->
                     <!-- ko if: item.apiVersion -->
                     - <span data-bind="text: item.apiVersion"></span>
                     <!-- /ko -->


### PR DESCRIPTION
This is related to #428 (which resolved issue #371 ) but neglected to add the SOAP badge on the product page