### PR TITLE
Use access key for configure.js and set exit code in migrate.js

### DIFF
--- a/scripts.v2/configure.js
+++ b/scripts.v2/configure.js
@@ -1,13 +1,17 @@
 const fs = require('fs'),
+    crypto = require('crypto'),
     path = require('path'),
     configDesignFile = path.join(__dirname, '\\..\\src\\config.design.json'),
     configPublishFile = path.join(__dirname, '\\..\\src\\config.publish.json'),
     configRuntimeFile = path.join(__dirname, '\\..\\src\\config.runtime.json');
 
-const managementEndpoint = process.argv[2];
-const apimSasAccessTokenValue = process.argv[3];
-const backendUrlValue = process.argv[4];
-const apimServiceNameValue = process.argv[5];
+const apimServiceNameValue = process.argv[2];
+const apimAccountKey = process.argv[3];
+
+const managementEndpoint =  `${apimServiceNameValue}.management.azure-api.net`;
+const apimSasAccessTokenValue = createSharedAccessToken("integration", apimAccountKey, 14);
+const backendUrlValue = `https://${apimServiceNameValue}.developer.azure-api.net`;
+
 const apimServiceUrlValue = `https://${managementEndpoint}/subscriptions/00000/resourceGroups/00000/providers/Microsoft.ApiManagement/service/${apimServiceNameValue}`;
 
 const apimServiceParameter = "managementApiUrl";
@@ -59,3 +63,17 @@ fs.readFile(configRuntimeFile, { encoding: 'utf-8' }, function (err, data) {
         console.log(err);
     }
 });
+
+function createSharedAccessToken(apimUid, apimAccessKey, validDays) {
+
+    const expiryDate = new Date()
+    expiryDate.setDate(expiryDate.getDate() + validDays)
+
+    let expiry = expiryDate.toISOString().replace(/\d+.\d+Z/, "00.0000000Z")
+    let expiryShort = expiryDate.toISOString().substr(0,16).replace(/[^\d]/g,'',)
+
+    const signature = crypto.createHmac('sha512', apimAccessKey).update(`${apimUid}\n${expiry}`).digest('base64');
+    const sasToken = `SharedAccessSignature ${apimUid}&${expiryShort}&${signature}`;
+
+    return sasToken;
+}

--- a/scripts.v2/migrate.js
+++ b/scripts.v2/migrate.js
@@ -184,5 +184,6 @@ run()
         console.log("DONE");
     })
     .catch(error => {
-        console.log(error);
+        console.error(error);
+        process.exitCode = 1;
     });


### PR DESCRIPTION
There's probably a good reason why you don't do it this way but... 

It seems that some of the variables required for the configure script could be derived/generated using the service name and access key.  So I thought I'd suggest a configure script that only uses those.

EDIT: Also included a suggestion to set the exit code in migrate.js, currently it still exits successfully even if it fails