### PR TITLE
Fix typo

### DIFF
--- a/src/components/reports/ko/runtime/reports.ts
+++ b/src/components/reports/ko/runtime/reports.ts
@@ -444,7 +444,7 @@ export class Reports {
                 color: "#a0cef5"
             },
             {
-                displayName: "Successfull requests",
+                displayName: "Successful requests",
                 key: "callCountSuccess",
                 color: "#7fba00"
             },


### PR DESCRIPTION
This PR fixes a typo: `successfull` should be `successful`.