### PR TITLE
Error state of non-existent API and Readability of subscription key

### DIFF
--- a/src/components/apis/details-of-api/ko/runtime/api-details.html
+++ b/src/components/apis/details-of-api/ko/runtime/api-details.html
@@ -21,7 +21,8 @@
                     data-bind="options: versionApis, optionsValue: 'name', optionsText: 'apiVersion', value: currentApiVersion">
                 </select>
                 <!-- /ko -->
-                <select id="apiDefinitions" class="form-control" aria-label="API definitions" data-bind="value: downloadSelected">
+                <select id="apiDefinitions" class="form-control" aria-label="API definitions"
+                    data-bind="value: downloadSelected">
                     <option value="" disabled="disabled" selected="selected">API definition</option>
                     <option value="openapi">Open API 3 (YAML)</option>
                     <option value="openapi+json">Open API 3 (JSON)</option>
@@ -44,8 +45,9 @@
         <!-- /ko -->
 
         <!-- ko ifnot: api -->
-        <p>No API selected</p>
+        <p>No such API available</p>
         <!-- /ko -->
+
     </div>
     <!-- /ko -->
 

--- a/src/components/apis/details-of-api/ko/runtime/api-details.html
+++ b/src/components/apis/details-of-api/ko/runtime/api-details.html
@@ -45,7 +45,7 @@
         <!-- /ko -->
 
         <!-- ko ifnot: api -->
-        <p>No such API available</p>
+        <p>The specified API does not exist.</p>
         <!-- /ko -->
 
     </div>

--- a/src/components/apis/details-of-api/ko/runtime/api-details.ts
+++ b/src/components/apis/details-of-api/ko/runtime/api-details.ts
@@ -20,6 +20,7 @@ export class ApiDetails {
     public readonly currentApiVersion: ko.Observable<string>;
     public readonly versionApis: ko.ObservableArray<Api>;
     public readonly working: ko.Observable<boolean>;
+    public readonly errorMessage: ko.Observable<string>;
     public readonly downloadSelected: ko.Observable<string>;
 
     constructor(
@@ -32,6 +33,7 @@ export class ApiDetails {
         this.selectedApiName = ko.observable();
         this.versionApis = ko.observableArray([]);
         this.working = ko.observable(false);
+        this.errorMessage = ko.observable();
         this.currentApiVersion = ko.observable();
         this.downloadSelected = ko.observable("");
         this.loadApi = this.loadApi.bind(this);
@@ -73,10 +75,13 @@ export class ApiDetails {
             return;
         }
 
-        this.working(true);
-
         const api = await this.apiService.getApi(`apis/${apiName}`);
+        if (!api) {
+            this.api(null);
+            return;
+        }
 
+        this.working(true);
         if (api.apiVersionSet && api.apiVersionSet.id) {
             const apis = await this.apiService.getApisInVersionSet(api.apiVersionSet.id);
             apis.forEach(x => x.apiVersion = x.apiVersion || "Original");
@@ -148,7 +153,7 @@ export class ApiDetails {
 
     private onVersionChange(selectedApiName: string): void {
         const apiName = this.routeHelper.getApiName();
-        if(apiName !== selectedApiName) {
+        if (apiName !== selectedApiName) {
             const apiUrl = this.routeHelper.getApiReferenceUrl(selectedApiName);
             this.router.navigateTo(apiUrl);
         }

--- a/src/components/operations/operation-details/ko/runtime/operation-console.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.ts
@@ -253,12 +253,14 @@ export class OperationConsole {
                 }
 
                 keys.push({
-                    name: `Primary-${subscription.primaryKey.substr(0, 4)}`,
+                    name: `Primary-${subscription.name}`,
+                    //name: `Primary-${subscription.primaryKey.substr(0, 4)}`,
                     value: subscription.primaryKey
                 });
 
                 keys.push({
-                    name: `Secondary-${subscription.secondaryKey.substr(0, 4)}`,
+                    name: `Secondary-${subscription.name}`,
+                    //name: `Secondary-${subscription.secondaryKey.substr(0, 4)}`,
                     value: subscription.secondaryKey
                 });
             });

--- a/src/components/operations/operation-details/ko/runtime/operation-console.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.ts
@@ -253,13 +253,13 @@ export class OperationConsole {
                 }
 
                 keys.push({
-                    name: `Primary-${subscription.name}`,
+                    name: `Primary: ${((subscription.name == null) || (subscription.name.trim()) ? subscription.name : subscription.primaryKey.substr(0, 4))}`,
                     //name: `Primary-${subscription.primaryKey.substr(0, 4)}`,
                     value: subscription.primaryKey
                 });
 
                 keys.push({
-                    name: `Secondary-${subscription.name}`,
+                    name: `Secondary: ${((subscription.name == null) || (subscription.name.trim()) ? subscription.name : subscription.secondaryKey.substr(0, 4))}`,
                     //name: `Secondary-${subscription.secondaryKey.substr(0, 4)}`,
                     value: subscription.secondaryKey
                 });


### PR DESCRIPTION
Fixed the error state of the non-existent (Issue #972). The error message when accessing a deleted or non existent API looks as follows:
![image](https://user-images.githubusercontent.com/58763328/96423390-e5dd5400-1216-11eb-9dd0-1dbba4ce0c48.png)



Also modified the name of the subscription key that is used in Try It, referenced in Issue #945. Changed the format from "Primary-191f" to "Primary-SubName".
![image](https://user-images.githubusercontent.com/58763328/96424527-6fd9ec80-1218-11eb-84f4-a7df019946a0.png)
