### PR TITLE
Fix Operation Console for SOAP 1.2 Content-Type

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/operation-console.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.ts
@@ -219,8 +219,8 @@ export class OperationConsole {
                     .find(header => header.name().toLowerCase() === KnownHttpHeaders.ContentType.toLowerCase());
 
                 if (contentHeader) {
-                    const contentType = `${contentHeader.value};action="${consoleOperation.urlTemplate.split("=")[1]}"`;
-                    consoleOperation.setHeader(KnownHttpHeaders.ContentType, contentType);
+                    const contentType = `${contentHeader.value()};action="${consoleOperation.urlTemplate.split("=")[1]}"`;
+                    contentHeader.value(contentType);
                 }
             }
         }


### PR DESCRIPTION
The "Try It" console doesn't display the correct headers for SOAP 1.2 APIs due to some minor errors in the code:

 - `ConsoleHeader.value` has tyoe `ko.Observable<string>` so needs to be called as function
 - `consoleOperation.setHeader()` pushes a new Content-Type header, so instead just update the value of the existing one