### PR TITLE
Fix for migration between subscription-to-subscription apim developer portal

### DIFF
--- a/scripts.v3/migrate.js
+++ b/scripts.v3/migrate.js
@@ -13,15 +13,15 @@
  *    --sourceSubscriptionId "< your subscription ID >" ^
  *    --sourceResourceGroupName "< your resource group name >" ^
  *    --sourceServiceName "< your service name >" ^
- *    --sourceTenantid "< source tenant id >" ^
- *    --sourceServiceprincipal "< source serviceprincipal or user name. >" ^
- *    --sourceSecret "< secret or password for service principal or az login for the source apim. >" ^
+ *    --sourceTenantid "< optional (needed if source and destination is in different subscription) source tenant id >" ^
+ *    --sourceServiceprincipal "< optional (needed if source and destination is in different subscription) source serviceprincipal or user name. >" ^
+ *    --sourceSecret "< optional (needed if source and destination is in different subscription) secret or password for service principal or az login for the source apim. >" ^
  *    --destSubscriptionId "< your subscription ID >" ^
  *    --destResourceGroupName "< your resource group name >" ^
  *    --destServiceName "< your service name >"
- *    --destTenantid "<  destination tenantid >"
- *    --destServiceprincipal "<destination serviceprincipal or user name. >"
- *    --destSecret "< secret or password for service principal or az login for the destination. >"
+ *    --destTenantid "< optional (needed if source and destination is in different subscription) destination tenantid >"
+ *    --destServiceprincipal "< optional (needed if source and destination is in different subscription)destination serviceprincipal or user name. >"
+ *    --destSecret "< optional (needed if source and destination is in different subscription) secret or password for service principal or az login for the destination. >"
  * 
  * Auto-publishing is not supported for self-hosted versions, so make sure you publish the portal (for example, locally)
  * and upload the generated static files to your hosting after the migration is completed.
@@ -37,15 +37,15 @@ const yargs = require('yargs')
     *    --sourceSubscriptionId "< your subscription ID > \r
     *    --sourceResourceGroupName "< your resource group name > \r
     *    --sourceServiceName "< your service name > \r
-    *    --sourceTenantid "< source tenant id > \r
-    *    --sourceServiceprincipal "< source serviceprincipal or user name. > \r
-    *    --sourceSecret "< secret or password for service principal or az login for the source apim. > \r
+    *    --sourceTenantid "< optional (needed if source and destination is in different subscription) source tenant id > \r
+    *    --sourceServiceprincipal "< optional (needed if source and destination is in different subscription) source serviceprincipal or user name. > \r
+    *    --sourceSecret "< optional (needed if source and destination is in different subscription) secret or password for service principal or az login for the source apim. > \r
     *    --destSubscriptionId "< your subscription ID > \r
     *    --destResourceGroupName "< your resource group name > \r
     *    --destServiceName "< your service name > \r
-    *    --destTenantid "<  destination tenantid > \r
-    *    --destServiceprincipal "<destination serviceprincipal or user name. > \r
-    *    --destSecret "< secret or password for service principal or az login for the destination. >\n`)
+    *    --destTenantid "< optional (needed if source and destination is in different subscription) destination tenantid > \r
+    *    --destServiceprincipal "< optional (needed if source and destination is in different subscription) destination serviceprincipal or user name. > \r
+    *    --destSecret "< optional (needed if source and destination is in different subscription) secret or password for service principal or az login for the destination. >\n`)
     .option('sourceSubscriptionId', {
         type: 'string',
         description: 'Azure subscription ID.',

--- a/scripts.v3/migrate.js
+++ b/scripts.v3/migrate.js
@@ -13,7 +13,7 @@
  *    --sourceSubscriptionId "< your subscription ID >" ^
  *    --sourceResourceGroupName "< your resource group name >" ^
  *    --sourceServiceName "< your service name >" ^
- *    --sourceTenantid "< your service name >" ^
+ *    --sourceTenantid "< source tenant id >" ^
  *    --sourceServiceprincipal "< source serviceprincipal or user name. >" ^
  *    --sourceSecret "< secret or password for service principal or az login for the source apim. >" ^
  *    --destSubscriptionId "< your subscription ID >" ^
@@ -37,7 +37,7 @@ const yargs = require('yargs')
     *    --sourceSubscriptionId "< your subscription ID > \r
     *    --sourceResourceGroupName "< your resource group name > \r
     *    --sourceServiceName "< your service name > \r
-    *    --sourceTenantid "< your service name > \r
+    *    --sourceTenantid "< source tenant id > \r
     *    --sourceServiceprincipal "< source serviceprincipal or user name. > \r
     *    --sourceSecret "< secret or password for service principal or az login for the source apim. > \r
     *    --destSubscriptionId "< your subscription ID > \r

--- a/scripts.v3/migrate.js
+++ b/scripts.v3/migrate.js
@@ -13,9 +13,15 @@
  *    --sourceSubscriptionId "< your subscription ID >" ^
  *    --sourceResourceGroupName "< your resource group name >" ^
  *    --sourceServiceName "< your service name >" ^
+ *    --sourceTenantid "< your service name >" ^
+ *    --sourceServiceprincipal "< source serviceprincipal or user name. >" ^
+ *    --sourceSecret "< secret or password for service principal or az login for the source apim. >" ^
  *    --destSubscriptionId "< your subscription ID >" ^
  *    --destResourceGroupName "< your resource group name >" ^
  *    --destServiceName "< your service name >"
+ *    --destTenantid "<  destination tenantid >"
+ *    --destServiceprincipal "<destination serviceprincipal or user name. >"
+ *    --destSecret "< secret or password for service principal or az login for the destination. >"
  * 
  * Auto-publishing is not supported for self-hosted versions, so make sure you publish the portal (for example, locally)
  * and upload the generated static files to your hosting after the migration is completed.
@@ -28,12 +34,18 @@ const { ImporterExporter } = require('./utils.js');
 
 const yargs = require('yargs')
     .example(`node ./migrate ^ \r
-        --sourceSubscriptionId "< your subscription ID > ^ \r
-        --sourceResourceGroupName "< your resource group name >" ^ \r
-        --sourceServiceName "< your service name >" ^ \r
-        --destSubscriptionId "< your subscription ID >" ^ \r
-        --destResourceGroupName "< your resource group name >" ^ \r
-        --destServiceName "< your service name >"\n`)
+    *    --sourceSubscriptionId "< your subscription ID > \r
+    *    --sourceResourceGroupName "< your resource group name > \r
+    *    --sourceServiceName "< your service name > \r
+    *    --sourceTenantid "< your service name > \r
+    *    --sourceServiceprincipal "< source serviceprincipal or user name. > \r
+    *    --sourceSecret "< secret or password for service principal or az login for the source apim. > \r
+    *    --destSubscriptionId "< your subscription ID > \r
+    *    --destResourceGroupName "< your resource group name > \r
+    *    --destServiceName "< your service name > \r
+    *    --destTenantid "<  destination tenantid > \r
+    *    --destServiceprincipal "<destination serviceprincipal or user name. > \r
+    *    --destSecret "< secret or password for service principal or az login for the destination. >\n`)
     .option('sourceSubscriptionId', {
         type: 'string',
         description: 'Azure subscription ID.',
@@ -48,6 +60,21 @@ const yargs = require('yargs')
         type: 'string',
         description: 'API Management service name.',
         demandOption: true
+    })
+    .option('sourceTenantid', {
+        type: 'string',
+        description: 'source tenantid.',
+        demandOption: false
+    })
+    .option('sourceServiceprincipal', {
+        type: 'string',
+        description: 'source serviceprincipal or user name.',
+        demandOption: false
+    })
+    .option('sourceSecret', {
+        type: 'string',
+        description: 'secret or password for service principal or az login for the source apim.',
+        demandOption: false
     })
     .option('destSubscriptionId', {
         type: 'string',
@@ -64,15 +91,30 @@ const yargs = require('yargs')
         description: 'API Management service name.',
         demandOption: true
     })
+    .option('destTenantid', {
+        type: 'string',
+        description: ' destination tenantid.',
+        demandOption: false
+    })
+    .option('destServiceprincipal', {
+        type: 'string',
+        description: 'destination serviceprincipal or user name.',
+        demandOption: false
+    })
+    .option('destSecret', {
+        type: 'string',
+        description: 'secret or password for service principal or az login for the destination.',
+        demandOption: false
+    })
     .help()
     .argv;
 
 async function migrate() {
     try {
-        const sourceImporterExporter = new ImporterExporter(yargs.sourceSubscriptionId, yargs.sourceResourceGroupName, yargs.sourceServiceName);
+        const sourceImporterExporter = new ImporterExporter(yargs.sourceSubscriptionId, yargs.sourceResourceGroupName, yargs.sourceServiceName, yargs.sourceTenantid, yargs.sourceServiceprincipal, yargs.sourceSecret);
         await sourceImporterExporter.export();
     
-        const destIimporterExporter = new ImporterExporter(yargs.destSubscriptionId, yargs.destResourceGroupName, yargs.destServiceName);
+        const destIimporterExporter = new ImporterExporter(yargs.destSubscriptionId, yargs.destResourceGroupName, yargs.destServiceName, yargs.destTenantid, yargs.destServiceprincipal, yargs.destSecret);
         await destIimporterExporter.cleanup();
         await destIimporterExporter.import();
     

--- a/scripts.v3/utils.js
+++ b/scripts.v3/utils.js
@@ -10,12 +10,12 @@ const managementApiEndpoint = "management.azure.com";
 
 
 class HttpClient {
-    constructor(subscriptionId, resourceGroupName, serviceName) {
+    constructor(subscriptionId, resourceGroupName, serviceName, tenantid, serviceprincipal, secret) {
         this.subscriptionId = subscriptionId;
         this.resourceGroupName = resourceGroupName;
         this.serviceName = serviceName;
         this.baseUrl = `https://${managementApiEndpoint}/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.ApiManagement/service/${serviceName}`;
-        this.accessToken = this.getAccessToken();
+        this.accessToken = this.getAccessToken(tenantid, serviceprincipal, secret);
     }
 
     /**
@@ -103,14 +103,20 @@ class HttpClient {
         });
     }
 
-    getAccessToken() {
+    getAccessToken(tenantid, serviceprincipal, secret) {
+
+        if (tenantid != "" && tenantid != null)
+        {
+            execSync(`az login --service-principal --username ` + serviceprincipal + ` --password ` + secret + ` --tenant ` + tenantid);
+        }
+
         const accessToken = execSync(`az account get-access-token --resource-type arm --output tsv --query accessToken`).toString().trim();
         return `Bearer ${accessToken}`;
     }
 }
 class ImporterExporter {
-    constructor(subscriptionId, resourceGroupName, serviceName, snapshotFolder = "../dist/snapshot") {
-        this.httpClient = new HttpClient(subscriptionId, resourceGroupName, serviceName);
+    constructor(subscriptionId, resourceGroupName, serviceName, tenantid, serviceprincipal, secret, snapshotFolder = "../dist/snapshot") {
+        this.httpClient = new HttpClient(subscriptionId, resourceGroupName, serviceName, tenantid, serviceprincipal, secret);
         this.snapshotFolder = snapshotFolder
     }
 


### PR DESCRIPTION
### Fix for migration between subscription-to-subscription apim developer portal by passing the az login details in parameters

Migration failing if the source and destination is on different subscription because azure cli access is not there in one apim which causes unauthorized error on generating sas token to migrate.

So parameterized the az cli login details to the command line for source and destination from command arguments below:

Following are the parameters added to pass while running and are optional for users

 *    --sourceTenantid "< your service name >" ^
 *    --sourceServiceprincipal "< source serviceprincipal or user name. >" ^
 *    --sourceSecret "< secret or password for service principal or az login for the source apim. >" ^
 *    --destTenantid "<  destination tenantid >"
 *    --destServiceprincipal "<destination serviceprincipal or user name. >"
 *    --destSecret "< secret or password for service principal or az login for the destination. >"

its a fix for issue : https://github.com/Azure/api-management-developer-portal/issues/1144