### PR TITLE
Process for migration scripts will return when underlying script fails

### DIFF
--- a/scripts.v2/capture.js
+++ b/scripts.v2/capture.js
@@ -85,4 +85,5 @@ capture()
     })
     .catch(error => {
         console.log(error.message);
+        process.exitCode = 1;
     });

--- a/scripts.v2/cleanup.js
+++ b/scripts.v2/cleanup.js
@@ -62,4 +62,5 @@ cleanup()
     })
     .catch(error => {
         console.log(error.message);
+        process.exitCode = 1;        
     });

--- a/scripts.v2/generate.js
+++ b/scripts.v2/generate.js
@@ -43,4 +43,5 @@ generate()
     })
     .catch(error => {
         console.log(error.message);
+        process.exitCode = 1;
     });


### PR DESCRIPTION
Currently during migration run errors that happen in underlying scripts (executed within execSync) got swallowed.

After the change, execSync will trigger exception when non-zero return code is received and you will receive error to console.