### PR TITLE
Fix for parameter check in migrate.js

### DIFF
--- a/scripts.v2/migrate.js
+++ b/scripts.v2/migrate.js
@@ -95,7 +95,7 @@ const yargs = require('yargs')
         type: 'string',
         example: 'SharedAccessSignature…',
         description: 'A SAS token for the destination portal',
-        conflicts: ['destId, destToken']
+        conflicts: ['destId, destKey']
     })
     .argv;
 


### PR DESCRIPTION
It should check for destId or **destKey** when the destToken parameter is being used. It didn't check for destKey. 