### PR TITLE
Increase apiversion to handle the case when minimum apiversion has been set

### DIFF
--- a/scripts.v3/utils.js
+++ b/scripts.v3/utils.js
@@ -5,7 +5,7 @@ const { execSync } = require("child_process");
 const { BlobServiceClient } = require("@azure/storage-blob");
 const blobStorageContainer = "content";
 const mime = require("mime-types");
-const apiVersion = "2019-01-01"; // "2021-01-01-preview"; 
+const apiVersion = "2020-06-01-preview"; // "2021-01-01-preview"; 
 const managementApiEndpoint = "management.azure.com";
 
 


### PR DESCRIPTION
If you set "Prevent users with read-only permissions from accessing service secrets" it will set the Minimum API version to 2019-12-01 for the Management API.

That stops the capture and generate scripts in the scripts.v3 folder from working. 

This PR increases the apiVersion used in the scripts from 2019-01-01 to 2020-06-01-preview, which makes them work again.
