### PR TITLE
[scripts.v3] fix: http request false failure on 202

### DIFF
--- a/scripts.v3/utils.js
+++ b/scripts.v3/utils.js
@@ -74,6 +74,7 @@ class HttpClient {
                     switch (resp.statusCode) {
                         case 200:
                         case 201:
+                        case 202:
                             data.startsWith("{") ? resolve(JSON.parse(data)) : resolve(data);
                             break;
                         case 404:


### PR DESCRIPTION
When executing `node ./migrate`, it returns:

```
Exporting...
Cleaning up...
Importing...
Unable to complete migration. Unable to schedule website publishing. Could not complete request to https://management.azure.com/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/rg-name/providers/Microsoft.ApiManagement/service/apim-name/portalRevisions/20210413073209?api-version=2020-06-01-preview. Status: 202 Accepted
```
Response code 202 is the expected behavior per Azure API Management REST API reference: https://docs.microsoft.com/en-us/rest/api/apimanagement/2020-06-01-preview/portalrevision/createorupdate

This pull request makes response code 202 an acceptable response from the API