### PR TITLE
Added missing hamburger icon style.

### DIFF
--- a/src/themes/website/styles/icons.scss
+++ b/src/themes/website/styles/icons.scss
@@ -124,6 +124,10 @@
     content: "\e910";
 }
 
+.icon-emb-menu-8:before {
+    content: "\e90e";
+}
+
 .icon-emb-wadl {
     @include icon-18px();
     background-color: transparent;


### PR DESCRIPTION
This is a small fix for the missing icon, not the ultimate solution though because of the hamburger color, which cannot be configured yet (it might be a visibility problem on dark backgrounds). A complete solution is coming soon.

![image](https://user-images.githubusercontent.com/2320302/115795931-b7872f80-a385-11eb-9894-3758f170f806.png)

Closes: #1260, #1187, #496.
