### PR TITLE
use update instead of init in markdown bindingHandler

### DIFF
--- a/src/bindingHandlers/markdown.ts
+++ b/src/bindingHandlers/markdown.ts
@@ -17,7 +17,7 @@ interface MarkdownConfig {
 
 
 ko.bindingHandlers["markdown"] = {
-    init: (element: HTMLElement, valueAccessor: () => string | MarkdownConfig): void => {
+    update: (element: HTMLElement, valueAccessor: () => string | MarkdownConfig): void => {
         const config = ko.unwrap(valueAccessor());
         const htmlObservable = ko.observable();
 


### PR DESCRIPTION
I followed the guide to implement a custom widget (https://docs.microsoft.com/en-gb/azure/api-management/developer-portal-implement-widgets ) but had problems getting the markdown binding working.

After some debugging I found out it seems to be related to the `httpClient.send` await.
The markdown binding is called before the http response is returned with an empty value.

After taking a look at the other custom `bindingHandlers` they all use the `update` callback method (see https://knockoutjs.com/documentation/custom-bindings.html ).

 