### PR TITLE
Added support for multipart request body in Test console

### DIFF
--- a/src/components/file-input/file-input.ts
+++ b/src/components/file-input/file-input.ts
@@ -1,8 +1,7 @@
 import * as ko from "knockout";
 import template from "./file-input.html";
 import { Utils } from "../../utils";
-import { Component, Event } from "@paperbits/common/ko/decorators";
-
+import { Component, Event, Param } from "@paperbits/common/ko/decorators";
 
 @Component({
     selector: "file-input",
@@ -14,6 +13,9 @@ export class FileInput {
 
     @Event()
     public onSelect: (file: File) => void;
+
+    @Param()
+    public containerItem: {binary: ko.Observable<File>};
 
     constructor() {
         this.selectedFileInfo = ko.observable<string>();
@@ -39,11 +41,11 @@ export class FileInput {
             const file: File = event.target.files[0];
             
             this.selectedFileInfo(`${file.name} (${Utils.formatBytes(file.size)})`);
-
-            this.onSelect(file);
+            this.containerItem && this.containerItem.binary(file);
+            this.onSelect && this.onSelect(file);
         }
         else {
-            this.onSelect(null);
+            this.onSelect && this.onSelect(null);
         }
     }
 }

--- a/src/components/operations/operation-details/ko/runtime/operation-console.html
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.html
@@ -271,17 +271,25 @@
     <h3>Body</h3>
 
     <div class="flex justify-content-end">
+        <!-- ko if: request.readonlyBodyFormat -->
+        <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="bodyFormat" id="bodyFormatForm" value="form"
+                data-bind="checked: request.bodyFormat, attr: { disabled: request.readonlyBodyFormat}">
+            <label class="form-check-label" for="bodyFormatRaw">Form-data</label>
+        </div>
+        <!-- /ko -->
         <div class="form-check form-check-inline">
             <input class="form-check-input" type="radio" name="bodyFormat" id="bodyFormatRaw" value="raw"
-                data-bind="checked: request.bodyFormat">
+                data-bind="checked: request.bodyFormat, attr: { disabled: request.readonlyBodyFormat}">
             <label class="form-check-label" for="bodyFormatRaw">Raw</label>
         </div>
         <div class="form-check form-check-inline">
             <input class="form-check-input" type="radio" name="bodyFormat" id="bodyFormatBinary" value="binary"
-                data-bind="checked: request.bodyFormat">
+                data-bind="checked: request.bodyFormat, attr: { disabled: request.readonlyBodyFormat}">
             <label class="form-check-label" for="bodyFormatBinary">Binary</label>
         </div>
     </div>
+    <!-- ko ifnot: request.readonlyBodyFormat -->
     <div class="form-group">
         <!-- ko if: request.bodyFormat() === 'raw' -->
         <textarea class="form-control form-control-sm" rows="5" aria-label="Request body"
@@ -294,10 +302,35 @@
         <!-- /ko -->
     </div>
     <!-- /ko -->
+    <!-- ko if: request.readonlyBodyFormat -->
+    <div data-bind="foreach: { data: request.bodyDataItems, as: 'item' }">
+        <div class="input-label">
+            <span class="text-monospace item-label" data-bind="text: item.name"></span><span class="text-monospace" data-bind="text: '(type: ' + item.type() + ')'"></span>
+        </div>
+        <div class="form-group">
+            <!-- ko if: item.bodyFormat() === 'string' -->
+            <div class="input-group">
+                <input type="text" autocomplete="off" class="form-control form-control-sm" spellcheck="false" data-bind="event: { keyup: $component.updateRequestSummary }, textInput: item.body">
+            </div>
+            <!-- /ko -->
+            <!-- ko if: item.bodyFormat() === 'raw' -->
+            <textarea class="form-control form-control-sm" rows="5" aria-label="Request body"
+                data-bind="event: { keyup: $component.updateRequestSummary }, textInput: item.body, valueUpdate: 'keyup'"></textarea>
+            <!-- /ko -->
+            <!-- ko if: item.bodyFormat() === 'binary' -->
+            <file-input params="{ containerItem: item }" class="form-control" aria-label="Request body" data-bind="css: { 'is-invalid': !item.binary.isValid() }"></file-input>
+            <span class="invalid-feedback" data-bind="validationMessage: item.binary"></span>
+            <!-- /ko -->
+        </div>
+    </div>
+    <!-- /ko -->
+
+    <!-- /ko -->
 </div>
 
 <!-- ko ifnot: api().type === 'websocket' -->
 <div class="panel panel-dark animation-fade-in panel-highlight flex-item flex-grow menu menu-horizontal">
+    <!-- ko ifnot: operation().request.isFormData() -->
     <ul class="nav" role="tablist">
         <li class="nav-item" role="presentation">
             <a class="nav-link" href="#" role="tab"
@@ -367,6 +400,8 @@
 
     <!-- ko if: $component.codeSample -->
     <pre data-bind="syntaxHighlight: { code: $component.codeSample, language: $component.selectedLanguage }"></pre>
+    <!-- /ko -->
+
     <!-- /ko -->
 
     <div class="flex flex-column align-items-end">

--- a/src/components/operations/operation-details/ko/runtime/operation-console.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.ts
@@ -4,7 +4,7 @@ import { ISettingsProvider } from "@paperbits/common/configuration";
 import { HttpClient, HttpRequest, HttpResponse } from "@paperbits/common/http";
 import { Component, OnMounted, Param } from "@paperbits/common/ko/decorators";
 import { SessionManager } from "@paperbits/common/persistence/sessionManager";
-import { ServiceSkuName, TypeOfApi } from "../../../../../constants";
+import { RequestBodyType, ServiceSkuName, TypeOfApi } from "../../../../../constants";
 import { SubscriptionState } from "../../../../../contracts/subscription";
 import { UnauthorizedError } from "../../../../../errors/unauthorizedError";
 import { Api } from "../../../../../models/api";
@@ -31,6 +31,7 @@ import template from "./operation-console.html";
 import { ResponsePackage } from "./responsePackage";
 import { templates } from "./templates/templates";
 import { LogItem, WebsocketClient } from "./websocketClient";
+import { FormDataItem } from "../../../../../models/console/formDataItem";
 
 const oauthSessionKey = "oauthSession";
 
@@ -563,12 +564,16 @@ export class OperationConsole {
         let payload;
 
         switch (consoleOperation.request.bodyFormat()) {
-            case "raw":
+            case RequestBodyType.raw:
                 payload = request.body();
                 break;
 
-            case "binary":
+            case RequestBodyType.binary:
                 payload = await Utils.readFileAsByteArray(request.binary());
+                break;
+
+            case RequestBodyType.form:
+                payload = request.getFormDataPayload();
                 break;
 
             default:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,16 @@ export enum TypeOfApi {
 }
 
 /**
+ * Types of body format.
+ */
+export enum RequestBodyType {
+    raw = "raw",
+    string = "string",
+    binary = "binary",
+    form = "form"
+}
+
+/**
  * Types of identity providers (values are case-sensitive).
  */
 export enum IdentityProviders {

--- a/src/contracts/searchQuery.ts
+++ b/src/contracts/searchQuery.ts
@@ -1,10 +1,36 @@
 import { Tag } from "./../models/tag";
 
+/**
+ * Search query.
+ */
 export interface SearchQuery {
+    /**
+     * Name of the property to search.
+     */
     propertyName?: string;
+
+    /**
+     * The value of the property to search.
+     */
     pattern?: string;
+
+    /**
+     * The tags to search for.
+     */
     tags?: Tag[];
+
+    /**
+     * Number of items to skip.
+     */
     skip?: number;
+
+    /**
+     * Number of items to return.
+     */
     take?: number;
+
+    /**
+     * Result grouping, e.g. `tag` or `none`.
+     */
     grouping?: string;
 }

--- a/src/models/console/consoleRequest.ts
+++ b/src/models/console/consoleRequest.ts
@@ -3,7 +3,8 @@ import { ConsoleParameter } from "./consoleParameter";
 import { ConsoleHeader } from "./consoleHeader";
 import { ConsoleRepresentation } from "./consoleRepresentation";
 import { Request } from "../request";
-
+import { RequestBodyType } from "../../constants";
+import { FormDataItem } from "./formDataItem";
 
 export class ConsoleRequest {
     public readonly queryParameters: ko.ObservableArray<ConsoleParameter>;
@@ -14,18 +15,24 @@ export class ConsoleRequest {
     public readonly body: ko.Observable<string>;
     public readonly hasBody: boolean;
     public readonly binary: ko.Observable<File>;
-    public readonly bodyFormat: ko.Observable<string>;
+    public readonly bodyFormat: ko.Observable<RequestBodyType>;
+    public readonly bodyDataItems: ko.ObservableArray<FormDataItem>;
+    public readonly representationContentType: string;
+    
+    public readonly readonlyBodyFormat: boolean;
 
     constructor(request: Request) {
         this.description = request.description;
         this.representations = request.representations.map(representation => new ConsoleRepresentation(representation));
         this.queryParameters = ko.observableArray(request.queryParameters.map(parameter => new ConsoleParameter(parameter)));
         this.headers = ko.observableArray(request.headers.map(header => new ConsoleHeader(header)));
-        this.body = ko.observable();
-        this.bodyFormat = ko.observable("raw");
-        this.binary = ko.observable();
-        this.binary.extend(<any>{ maxFileSize: 3 * 1024 * 1024 });
         this.meaningfulHeaders = ko.computed(() => this.headers().filter(x => !!x.value()));
+
+        this.body = ko.observable();
+        this.binary = ko.observable();
+        this.binary.extend(<any>{ maxFileSize: 3 * 1024 * 1024 });        
+        this.bodyFormat = ko.observable(RequestBodyType.raw);
+        this.bodyDataItems = ko.observableArray([]);
 
         if (this.representations?.length === 0) {
             return;
@@ -35,14 +42,53 @@ export class ConsoleRequest {
 
         this.body(representation.sample);
 
-        const contentType = representation.contentType;
+        this.representationContentType = representation.contentType;
 
-        if (contentType && this.headers().find(h => h.name() === "Content-Type") === undefined) {
-            const consoleHeader = new ConsoleHeader();
-            consoleHeader.name("Content-Type");
-            consoleHeader.value(contentType);
-            this.headers.push(consoleHeader);
+        // do not convert formParameters for contentType = application/x-www-form-urlencoded
+        // do not add Content-Type header for multipart/form-data
+        const bodyRepresentation = this.representationContentType === "multipart/form-data" && request.representations.find(r => r.formParameters?.length > 0);
+        if (bodyRepresentation) {
+            this.hasBody = true;
+            this.readonlyBodyFormat = true;
+            this.bodyFormat(RequestBodyType.form);
+            const dataItems = bodyRepresentation.formParameters.map(p => {
+                const item = new FormDataItem();
+                item.name(p.name);
+                item.type(p.type);
+                item.description(p.description);
+                item.required(p.required);
+                return item;
+            });
+            this.bodyDataItems(dataItems);
+        } else {
+            if (this.representationContentType && this.headers().find(h => h.name() === "Content-Type") === undefined) {
+                const consoleHeader = new ConsoleHeader();
+                consoleHeader.name("Content-Type");
+                consoleHeader.value(this.representationContentType);
+                this.headers.push(consoleHeader);
+            }
         }
+
+    }
+
+    public getFormDataPayload(): FormData {
+        const formData = new FormData();
+        const items = this.bodyDataItems();
+        for (let i = 0; i < items.length; i++) {
+            const item = items[i];
+            if (item.bodyFormat() === RequestBodyType.binary) {
+                const file = item.binary();
+                if (file) {
+                    formData.append(item.name(), file, file.name);
+                } else {
+                    formData.append(item.name(), "");
+                }
+                
+            } else {
+                formData.append(item.name(), item.body() || "");
+            }
+        }
+        return formData;
     }
 
     public requestHeaders(): ConsoleHeader[] {

--- a/src/models/console/formDataItem.ts
+++ b/src/models/console/formDataItem.ts
@@ -1,0 +1,43 @@
+import * as ko from "knockout";
+import { RequestBodyType } from "../../constants";
+
+export class FormDataItem {
+    public readonly name: ko.Observable<string>;
+    public readonly type: ko.Observable<string>;
+    public readonly description: ko.Observable<string>;
+    public readonly required: ko.Observable<boolean>;
+
+    public readonly body: ko.Observable<string>;
+    public readonly contentType: ko.Observable<string>;
+    public readonly binary: ko.Observable<File>;
+    public readonly bodyFormat: ko.Observable<RequestBodyType>;
+
+    constructor() {
+        this.name = ko.observable();
+        this.type = ko.observable();
+        this.description = ko.observable();
+        this.required = ko.observable();
+
+        this.body = ko.observable();
+        this.contentType = ko.observable();
+        this.binary = ko.observable();
+        this.binary.extend(<any>{ maxFileSize: 3 * 1024 * 1024 });        
+        this.bodyFormat = ko.observable(RequestBodyType.raw);
+
+        this.onSetValue = this.onSetValue.bind(this);
+        this.type.subscribe(this.onSetValue);
+    }
+    
+    private onSetValue(typeValue: any) {
+        switch (typeValue) {
+            case "file" :
+                this.bodyFormat(RequestBodyType.binary);
+                break;
+            case "object" :
+                this.bodyFormat(RequestBodyType.raw);
+                break;
+            default:
+                this.bodyFormat(RequestBodyType.string);            
+        }
+    }
+}

--- a/src/models/representation.ts
+++ b/src/models/representation.ts
@@ -1,5 +1,6 @@
 import { Utils } from "../utils";
 import { RepresentationContract } from "../contracts/representation";
+import { Parameter } from "./parameter";
 
 export class Representation {
     public contentType: string;
@@ -7,12 +8,20 @@ export class Representation {
     public exampleFormat: string;
     public schemaId: string;
     public typeName: string;
+    public formParameters: Parameter[];
 
     constructor(contract?: RepresentationContract) {
         this.contentType = contract.contentType;
         this.example = contract.sample || contract.generatedSample;
         this.schemaId = contract.schemaId;
         this.typeName = contract.typeName;
+
+        if (this.contentType === "multipart/form-data") {
+            this.typeName = "formData";
+            if (contract.formParameters?.length > 0){
+                this.formParameters = contract.formParameters.map(parameterContract => new Parameter("body", parameterContract)); 
+            }
+        }
 
         if (this.example) {
             if (this.contentType.includes("/xml")) {

--- a/src/models/request.ts
+++ b/src/models/request.ts
@@ -15,6 +15,13 @@ export class Request {
         return !!this.description || this.representations.some(x => !!x.typeName);
     }
 
+    /**
+     * Returns "true" if this request has multipart body.
+     */
+    public isFormData(): boolean {
+        return this.representations.some(x => x.typeName === "formData");
+    }
+
     public meaningfulRepresentations(): Representation[] {
         return this.representations.filter(x => !!x.typeName || !!x.example);
     }

--- a/src/themes/website/styles/flex.scss
+++ b/src/themes/website/styles/flex.scss
@@ -13,6 +13,10 @@
     flex-direction: column;
 }
 
+.flex-vertical-center {
+    align-items: center;
+}
+
 .flex-item {
     flex: 0 1 auto;
     align-self: auto;

--- a/src/themes/website/styles/forms.scss
+++ b/src/themes/website/styles/forms.scss
@@ -243,3 +243,10 @@ $search-button-width: 30px;
         margin: 0 10px;
     }
 }
+
+.input-label {
+    margin-bottom: 5px;
+    .item-label {
+        padding-right: 5px;
+    }
+}


### PR DESCRIPTION
Added loading multipart metadata from definitions.
Load form parameters in the test console.
Allow only form parameters from definitions and type multipart/form-data (do not support application/x-www-form-urlencoded).
Do not add a Content-type header for multipart/form-data requests in the test console. 