### PR TITLE
Support for setting folders and timestamp for the capture and generate scripts

### DIFF
--- a/scripts.v3/capture.js
+++ b/scripts.v3/capture.js
@@ -10,21 +10,19 @@
  * 
  * 3) Run this script with a valid combination of arguments:
  *    node ./capture ^
- *    --sourceSubscriptionId "< your subscription ID >" ^
- *    --sourceResourceGroupName "< your resource group name >" ^
- *    --sourceServiceName "< your service name >" ^
- *    --destSubscriptionId "< your subscription ID >" ^
- *    --destResourceGroupName "< your resource group name >" ^
- *    --destServiceName "< your service name >"
+ *   --subscriptionId < your subscription ID > ^
+ *   --resourceGroupName < your resource group name > ^
+ *   --serviceName < your service name >
  */
 
+const path = require("path");
 const { ImporterExporter } = require("./utils");
 
 const yargs = require('yargs')
     .example(`node ./capture ^ \r
-    --subscriptionId "< your subscription ID >" ^ \r
-    --resourceGroupName "< your resource group name >" ^ \r
-    --serviceName "< your service name >"\n`)
+     --subscriptionId "< your subscription ID >" ^ \r
+     --resourceGroupName "< your resource group name >" ^ \r
+     --serviceName "< your service name >"\n`)
     .option('subscriptionId', {
         type: 'string',
         description: 'Azure subscription ID.',
@@ -40,18 +38,70 @@ const yargs = require('yargs')
         description: 'API Management service name.',
         demandOption: true
     })
+    .option('folder', {
+        type: 'string',
+        default: '../dist/snapshot',
+        description: 'The path to the folder which will contain the content of the portal',
+        example: '../dist/snapshot',
+        demandOption: false
+    })
+    .option('timestamp', {
+        type: 'boolean',
+        description: 'Adds a timestamp to the folder where the content is stored',
+        demandOption: false
+    })
     .help()
     .argv;
 
 async function capture() {
+
+    // make the folder path understandable if running in Windows
+    const folder = yargs.folder.split("\\").join("/");
+
+    // get the absolute path
+    var absoluteFolder = path.resolve(folder);
+
+    // add the timestamp to the path if requested
+    if (yargs.timestamp) {
+        const timestamp = new Date();
+        const postfix = "-" +
+            timestamp.getFullYear() +
+            makeTwo(timestamp.getMonth() + 1) +
+            makeTwo(timestamp.getDate()) +
+            makeTwo(timestamp.getHours()) +
+            makeTwo(timestamp.getMinutes()) +
+            makeTwo(timestamp.getSeconds());
+
+        absoluteFolder += postfix;
+    }
+
     const importerExporter = new ImporterExporter(
         yargs.subscriptionId,
         yargs.resourceGroupName,
-        yargs.serviceName
+        yargs.serviceName,
+        null,
+        null,
+        null,
+        absoluteFolder
     );
+
     await importerExporter.export();
 
-    console.log(`The content captured in "./dist/snapshot" folder.`);
+    console.log(`The content was captured in the ${absoluteFolder} folder.`);
+}
+
+function makeTwo(digits) {
+    const asString = digits.toString();
+
+    if (asString.length == 0) {
+        return "00";
+    }
+
+    if (asString.length == 1) {
+        return "0" + asString;
+    }
+
+    return asString.slice(-2);
 }
 
 capture()

--- a/scripts.v3/generate.js
+++ b/scripts.v3/generate.js
@@ -10,60 +10,78 @@
  * 
  * 3) Run this script with a valid combination of arguments:
  *    node ./cleanup ^
- *    --sourceSubscriptionId "< your subscription ID >" ^
- *    --sourceResourceGroupName "< your resource group name >" ^
- *    --sourceServiceName "< your service name >" ^
- *    --destSubscriptionId "< your subscription ID >" ^
- *    --destResourceGroupName "< your resource group name >" ^
- *    --destServiceName "< your service name >"
+ *   --subscriptionId < your subscription ID > ^
+ *   --resourceGroupName < your resource group name > ^
+ *   --serviceName < your service name >
  */
 
-const { ImporterExporter } = require("./utils");
-
-const yargs = require('yargs')
-    .example(`node ./generate ^ \r
-    --subscriptionId "< your subscription ID >" ^ \r
-    --resourceGroupName "< your resource group name >" ^ \r
-    --serviceName "< your service name >"\n`)
-    .option('subscriptionId', {
-        type: 'string',
-        description: 'Azure subscription ID.',
-        demandOption: true
-    })
-    .option('resourceGroupName', {
-        type: 'string',
-        description: 'Azure resource group name.',
-        demandOption: true
-    })
-    .option('serviceName', {
-        type: 'string',
-        description: 'API Management service name.',
-        demandOption: true
-    })
-    .help()
-    .argv;
-
-async function generate() {
-    const importerExporter = new ImporterExporter(
-        yargs.subscriptionId,
-        yargs.resourceGroupName,
-        yargs.serviceName
-    );
-
-    await importerExporter.import();
-}
-
-generate()
-    .then(() => {
-        console.log("DONE");
-        process.exit(0);
-    })
-    .catch(error => {
-        console.error(error.message);
-        process.exit(1);
-    });
-
-
-module.exports = {
-    generate
-}
+ const path = require("path");
+ const { ImporterExporter } = require("./utils");
+ 
+ const yargs = require('yargs')
+     .example(`node ./generate ^ \r
+     --subscriptionId "< your subscription ID >" ^ \r
+     --resourceGroupName "< your resource group name >" ^ \r
+     --serviceName "< your service name >"\n`)
+     .option('subscriptionId', {
+         type: 'string',
+         description: 'Azure subscription ID.',
+         demandOption: true
+     })
+     .option('resourceGroupName', {
+         type: 'string',
+         description: 'Azure resource group name.',
+         demandOption: true
+     })
+     .option('serviceName', {
+         type: 'string',
+         description: 'API Management service name.',
+         demandOption: true
+     })
+     .option('folder', {
+         type: 'string',
+         default: '../dist/snapshot',
+         description: 'The path to the folder which contains the content to be uploaded to the portal',
+         example: '../dist/snapshot',
+         demandOption: false
+     })
+     .help()
+     .argv;
+ 
+ async function generate() {
+ 
+     // make the folder path understandable if running in Windows
+     const folder = yargs.folder.split("\\").join("/");
+ 
+     // get the absolute path
+     var absoluteFolder = path.resolve(folder);
+      console.log(`Going to upload the content in ${absoluteFolder}.`);
+ 
+     const importerExporter = new ImporterExporter(
+         yargs.subscriptionId,
+         yargs.resourceGroupName,
+         yargs.serviceName,
+         null,
+         null,
+         null,
+         absoluteFolder
+     );
+ 
+     await importerExporter.import();
+ }
+ 
+ generate()
+     .then(() => {
+         console.log("DONE");
+         process.exit(0);
+     })
+     .catch(error => {
+         console.error(error.message);
+         process.exit(1);
+     });
+ 
+ 
+ module.exports = {
+     generate
+ }
+ 

--- a/scripts.v3/utils.js
+++ b/scripts.v3/utils.js
@@ -195,7 +195,7 @@ class ImporterExporter {
      */
     async downloadBlobs() {
         try {
-            const snapshotMediaFolder = `./${this.snapshotFolder}/media`;
+            const snapshotMediaFolder = `${this.snapshotFolder}/media`;
             const blobStorageUrl = await this.getStorageSasUrl();
             const blobServiceClient = new BlobServiceClient(blobStorageUrl.replace(`/${blobStorageContainer}`, ""));
             const containerClient = blobServiceClient.getContainerClient(blobStorageContainer);
@@ -225,7 +225,7 @@ class ImporterExporter {
      */
     async uploadBlobs() {
         try {
-            const snapshotMediaFolder = `./${this.snapshotFolder}/media`;
+            const snapshotMediaFolder = `${this.snapshotFolder}/media`;
             const blobStorageUrl = await this.getStorageSasUrl();
             const blobServiceClient = new BlobServiceClient(blobStorageUrl.replace(`/${blobStorageContainer}`, ""));
             const containerClient = blobServiceClient.getContainerClient(blobStorageContainer);


### PR DESCRIPTION
Currently the capture and generate scripts are hardcoded to work with folders that are relative to the current working directory  which makes it difficult to determine where portal content is stored and picked up from. It also limits the options where content may be stored.

This PR enables setting the folder paths. It also enables saving the content of the portal in a new directory every time using a --timestamp argument.

This fixes #848.

It has only been test on Windows.