### PR TITLE
fix aadB2CClientConfig casing

### DIFF
--- a/src/components/users/signin-social/ko/runtime/signin-aad-b2c.ts
+++ b/src/components/users/signin-social/ko/runtime/signin-aad-b2c.ts
@@ -4,7 +4,7 @@ import { ISettingsProvider } from "@paperbits/common/configuration";
 import { EventManager } from "@paperbits/common/events";
 import { Component, OnMounted, Param, RuntimeComponent } from "@paperbits/common/ko/decorators";
 import { SettingNames } from "../../../../../constants";
-import { AadB2CClientConfig } from "../../../../../contracts/aadB2cClientConfig";
+import { AadB2CClientConfig } from "../../../../../contracts/aadB2CClientConfig";
 import { ValidationReport } from "../../../../../contracts/validationReport";
 import { AadService } from "../../../../../services";
 

--- a/src/services/runtimeConfigurator.ts
+++ b/src/services/runtimeConfigurator.ts
@@ -2,7 +2,7 @@ import { ISettingsProvider } from "@paperbits/common/configuration";
 import { SessionManager } from "@paperbits/common/persistence/sessionManager";
 import { IdentityService } from ".";
 import { SettingNames } from "../constants";
-import { AadB2CClientConfig } from "../contracts/aadB2cClientConfig";
+import { AadB2CClientConfig } from "../contracts/aadB2CClientConfig";
 import { AadClientConfig } from "../contracts/aadClientConfig";
 
 


### PR DESCRIPTION
We had an build error on linux machines due to wrong casing of the import statement for aadB2CClientConfig class.

there are two places where the import has the wrong casing (lower case c instead of upper case C).


The build error was:

```
2021-07-21T12:12:22.0697609Z     ERROR in /agent/_work/r1/a/_api-management-developer-portal/src/components/users/signin-social/ko/runtime/signin-aad-b2c.ts
2021-07-21T12:12:22.0698417Z     ./src/components/users/signin-social/ko/runtime/signin-aad-b2c.ts 7:35-80
2021-07-21T12:12:22.0699298Z     [tsl] ERROR in /agent/_work/r1/a/_api-management-developer-portal/src/components/users/signin-social/ko/runtime/signin-aad-b2c.ts(7,36)
2021-07-21T12:12:22.0700211Z           TS2307: Cannot find module '../../../../../contracts/aadB2cClientConfig' or its corresponding type declarations.
2021-07-21T12:12:22.0700700Z     
2021-07-21T12:12:22.0701345Z     ERROR in /agent/_work/r1/a/_api-management-developer-portal/src/services/runtimeConfigurator.ts
2021-07-21T12:12:22.0702171Z     [tsl] ERROR in /agent/_work/r1/a/_api-management-developer-portal/src/services/runtimeConfigurator.ts(5,36)
2021-07-21T12:12:22.0703019Z           TS2307: Cannot find module '../contracts/aadB2cClientConfig' or its corresponding type declarations.
2021-07-21T12:12:22.0704081Z     Child mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ref--4-1!node_modules/postcss-loader/dist/cjs.js!node_modules/sass-loader/dist/cjs.js!src/themes/website/styles/styles.scss:
2021-07-21T12:12:22.0704899Z         Entrypoint mini-css-extract-plugin = *
2021-07-21T12:12:22.0705897Z         [0] ./node_modules/css-loader/dist/cjs.js??ref--4-1!./node_modules/postcss-loader/dist/cjs.js!./node_modules/sass-loader/dist/cjs.js!./src/themes/website/styles/styles.scss 63.7 KiB {0} [built]
2021-07-21T12:12:22.0706523Z             + 1 hidden module
```