### PR TITLE
fix: capitalization of filename

### DIFF
--- a/src/components/users/signin-social/ko/runtime/signin-aad-b2c.ts
+++ b/src/components/users/signin-social/ko/runtime/signin-aad-b2c.ts
@@ -4,7 +4,7 @@ import { ISettingsProvider } from "@paperbits/common/configuration";
 import { EventManager } from "@paperbits/common/events";
 import { Component, OnMounted, Param, RuntimeComponent } from "@paperbits/common/ko/decorators";
 import { SettingNames } from "../../../../../constants";
-import { AadB2CClientConfig } from "../../../../../contracts/aadB2cClientConfig";
+import { AadB2CClientConfig } from "../../../../../contracts/aadB2CClientConfig";
 import { ValidationReport } from "../../../../../contracts/validationReport";
 import { AadService } from "../../../../../services";
 


### PR DESCRIPTION
filename is not capitalized correctly, which leads to build failures on linux systems (docker node:lts).