### PR TITLE
feat: ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 .history/
 .vs/
 .vscode/
+.DS_Store
 dist/
 node_modules/
 src/config.design.json
 src/config.publish.json
 src/config.runtime.json
+


### PR DESCRIPTION
Ignore .DS_Store files, generate by MAC OS X.