### PR TITLE
Add script to add GTM configuration and publish

### DIFF
--- a/scripts.v3/gtm.js
+++ b/scripts.v3/gtm.js
@@ -1,0 +1,82 @@
+/**
+ * This script add the Google Tag Manager (GTM) configuration to the API Management developer portal and publishes it.
+ * In order to run it, you need to:
+ * 
+ * 1) Clone the api-management-developer-portal repository:
+ *    git clone https://github.com/Azure/api-management-developer-portal.git
+ * 
+ * 2) Install NPM  packages:
+ *    npm install
+ * 
+ * 3) Run this script with a valid combination of arguments:
+ *    node ./gtm ^
+ *   --subscriptionId < your subscription ID > ^
+ *   --resourceGroupName < your resource group name > ^
+ *   --serviceName < your service name > ^
+ *   --gtmContainerId < gtm container ID >
+ */
+
+ const path = require("path");
+ const { ImporterExporter } = require("./utils");
+ 
+ const yargs = require('yargs')
+     .example(`node ./generate ^ \r
+     --subscriptionId "< your subscription ID >" ^ \r
+     --resourceGroupName "< your resource group name >" ^ \r
+     --serviceName "< your service name >"\r
+     --gtmContainerId "< gtm container ID >"\n`)
+     .option('subscriptionId', {
+         type: 'string',
+         description: 'Azure subscription ID.',
+         demandOption: true
+     })
+     .option('resourceGroupName', {
+         type: 'string',
+         description: 'Azure resource group name.',
+         demandOption: true
+     })
+     .option('serviceName', {
+         type: 'string',
+         description: 'API Management service name.',
+         demandOption: true
+     })
+     .option('gtmContainerId', {
+         type: 'string',
+         description: 'The Google Tag Manager container ID',
+         example: 'UA-XXXXXXX-X',
+         demandOption: true
+     })
+     .help()
+     .argv;
+ 
+ async function gtm() {   
+     const importerExporter = new ImporterExporter(
+         yargs.subscriptionId,
+         yargs.resourceGroupName,
+         yargs.serviceName,
+         null,
+         null,
+         null,
+         null,
+     );
+ 
+     await importerExporter.gtm(yargs.gtmContainerId);
+
+     await importerExporter.publish();
+ }
+ 
+ gtm()
+     .then(() => {
+         console.log("DONE");
+         process.exit(0);
+     })
+     .catch(error => {
+         console.error(error.message);
+         process.exit(1);
+     });
+ 
+ 
+ module.exports = {
+     gtm
+ }
+ 

--- a/scripts.v3/utils.js
+++ b/scripts.v3/utils.js
@@ -191,6 +191,43 @@ class ImporterExporter {
     }
 
     /**
+     * Returns a single content item of specified content type.
+     * @param {string} contentType Content type, e.g. "page".
+     * @param {string} contentItem Content item, e.g. "configuration".
+     */
+    async getContentItem(contentType, contentItem) {
+        try {
+            const url = `/contentTypes/${contentType}/contentItems/${contentItem}`;
+            
+            const data = await this.httpClient.sendRequest("GET", url);
+
+            return data;
+        }
+        catch (error) {
+            throw new Error(`Unable to fetch content item. ${error.message}`);
+        }
+    }
+
+    /**
+     * Updates a single content item of specified content type.
+     * @param {string} contentType Content type, e.g. "page".
+     * @param {string} contentItem Content item, e.g. "configuration".
+     * @param {object} body Request body .
+     */
+    async updateContentItem(contentType, contentItem, body) {
+        try {
+            const url = `/contentTypes/${contentType}/contentItems/${contentItem}`;
+            
+            const data = await this.httpClient.sendRequest("PUT", url, body);
+
+            return data;
+        }
+        catch (error) {
+            throw new Error(`Unable to update content item. ${error.message}`);
+        }
+    }
+
+    /**
      * Downloads media files from storage of specified API Management service.
      */
     async downloadBlobs() {
@@ -423,6 +460,32 @@ class ImporterExporter {
             throw new Error(`Unable to schedule website publishing. ${error.message}`);
         }
     }
+
+    /**
+     * Pushes the gtm tag to the specified APIM instance.
+     * @param {gtmTag} string the google tag manager Tag ID
+     */
+    async gtm(gtmTag) {
+        console.log("Applying GTM Tag...")
+        try {
+            const config = await this.getContentItem("document", "configuration");
+            const newNodes = config.properties.nodes.map((node) => {
+                return {...node, integration: {
+                    googleTagManager: {
+                        containerId: gtmTag
+                    }
+                }}
+            })
+            const newConfig = {...config, properties: {...config.properties, nodes: newNodes }}
+            
+            await this.updateContentItem("document", "configuration", newConfig)
+        }
+        catch (error) {
+            throw new Error(`Unable to apply gtm tag. ${error.message}`);
+        }
+    }
+
+
 }
 
 module.exports = {


### PR DESCRIPTION
This script will add the necessary GTM configuration through the Management API as described [here](https://docs.microsoft.com/en-us/azure/api-management/developer-portal-integrate-google-tag-manager)

Decided to add this as a separate script as I'm using the `migrate` script to migrate the Developer portal configuration from our `dev` to `prod` environments. Unfortunately the migration copies everything (including the GTM config) and therefore if you want different GTM config on `dev` and `prod` you need a separate way to do that. 

Plan is to run this script after I run the `dev` to `prod` migration script in my GitHub Actions workflow.