### PR TITLE
Fix broken code examples for csharp, php and objc

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/templates/csharp.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/csharp.liquid
@@ -14,16 +14,16 @@ namespace CSHttpClientSample
             Console.WriteLine("Hit ENTER to exit...");
             Console.ReadLine();
         }
-        
+
         static async void MakeRequest()
         {
             var client = new HttpClient();
             var queryString = HttpUtility.ParseQueryString(string.Empty);
 
-{% if meaningfulHeaders.size > 0 -%}
+{% if request.meaningfulHeaders.size > 0 -%}
             // Request headers
 {% for header in request.meaningfulHeaders -%}
-{% case header.Name -%}
+{% case header.name -%}
 {% when "Accept"%}
             client.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("{{header.value}}"));
 {% when "Accept-Charset" -%}
@@ -66,13 +66,12 @@ namespace CSHttpClientSample
             client.DefaultRequestHeaders.Upgrade.Add(ProductHeaderValue.Parse("{{header.value}}"));
 {% when "User-Agent" -%}
             client.DefaultRequestHeaders.UserAgent.Add(ProductInfoHeaderValue.Parse("{{header.value}}"));
-{% when "Via" -%}              
+{% when "Via" -%}
             client.DefaultRequestHeaders.Via.Add(ViaHeaderValue.Parse("{{header.value}}"));
 {% when "Warning" -%}
             client.DefaultRequestHeaders.Warning.Add(WarningHeaderValue.Parse("{{header.value}}"));
-{% when "Content-Type" -%}
 {% else -%}
-            client.DefaultRequestHeaders.Add("{{header.Name}}", "{{header.value}}");
+            client.DefaultRequestHeaders.Add("{{header.name}}", "{{header.value}}");
 {% endcase -%}
 {% endfor -%}
 {% endif -%}
@@ -128,9 +127,9 @@ namespace CSHttpClientSample
             if (response.Content != null)
             {
                 var responseString = await response.Content.ReadAsStringAsync();
-                Console.WriteLine(responseString);    
+                Console.WriteLine(responseString);
             }
 {% endcase -%}
         }
     }
-}	
+}

--- a/src/components/operations/operation-details/ko/runtime/templates/objc.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/objc.liquid
@@ -3,7 +3,7 @@
 int main(int argc, const char * argv[])
 {
     NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
-    
+
     NSString* path = @"{{requestUrl}}";
     NSArray* array = @[
                          // Request parameters
@@ -14,7 +14,7 @@ int main(int argc, const char * argv[])
 {% endfor -%}
 {% endif -%}
                       ];
-    
+
     NSString* string = [array componentsJoinedByString:@"&"];
     path = [path stringByAppendingFormat:@"?%@", string];
 
@@ -22,7 +22,7 @@ int main(int argc, const char * argv[])
 
     NSMutableURLRequest* _request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:path]];
     [_request setHTTPMethod:@"{{method}}"];
-{% if meaningfulHeaders.size > 0 -%}
+{% if request.meaningfulHeaders.size > 0 -%}
     // Request headers
 {% for header in request.meaningfulHeaders -%}
     [_request setValue:@"{{header.value}}" forHTTPHeaderField:@"{{header.name}}"];
@@ -32,7 +32,7 @@ int main(int argc, const char * argv[])
     // Request body
     [_request setHTTPBody:[@"{{ body | replace:'"','\"' }}" dataUsingEncoding:NSUTF8StringEncoding]];
 {% endif -%}
-    
+
     NSURLResponse *response = nil;
     NSError *error = nil;
     NSData* _connectionData = [NSURLConnection sendSynchronousRequest:_request returningResponse:&response error:&error];
@@ -47,21 +47,21 @@ int main(int argc, const char * argv[])
         NSMutableDictionary* json = nil;
         NSString* dataString = [[NSString alloc] initWithData:_connectionData encoding:NSUTF8StringEncoding];
         NSLog(@"%@", dataString);
-        
+
         if (nil != _connectionData)
         {
             json = [NSJSONSerialization JSONObjectWithData:_connectionData options:NSJSONReadingMutableContainers error:&error];
         }
-        
+
         if (error || !json)
         {
             NSLog(@"Could not parse loaded json with error:%@", error);
         }
-        
+
         NSLog(@"%@", json);
         _connectionData = nil;
     }
-    
+
     [pool drain];
 
     return 0;

--- a/src/components/operations/operation-details/ko/runtime/templates/php.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/php.liquid
@@ -5,7 +5,7 @@ require_once 'HTTP/Request2.php';
 $request = new Http_Request2('{{requestUrl}}');
 $url = $request->getUrl();
 
-{% if meaningfulHeaders.size > 0 -%}
+{% if request.meaningfulHeaders.size > 0 -%}
 $headers = array(
     // Request headers
 {% for header in request.meaningfulHeaders -%}


### PR DESCRIPTION
Fixes #1276

Code samples for C#, PHP and Objective-C are not including headers in the code samples, rendering the generated code useless for anyone that attempts to use them.