### PR TITLE
Added "serve-website" command to npm scripts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
         "build-function": "webpack --config webpack.function.js",
         "test": "node node_modules/mocha/bin/_mocha -r mocha.js src/**/*.spec.ts tests/e2e/**/*.spec.ts --timeout 30000",
         "deploy-function": "npm run build-function && cd dist/function && func azure functionapp publish < function app name >",
-        "publish": "webpack --config webpack.publisher.js && node dist/publisher/index.js && npm run preview-published",
-        "preview-published": "webpack-dev-server --open --contentBase dist/website --quiet"
+        "publish": "webpack --config webpack.publisher.js && node dist/publisher/index.js && npm run serve-website",
+        "serve-website": "webpack-dev-server --open --contentBase dist/website --quiet"
     },
     "devDependencies": {
         "@azure/storage-blob": "12.4.1",


### PR DESCRIPTION
Now you can serve your locally published website by running `npm run serve-website` command.