### PR TITLE
#1380 Fix accessibility issues with zoom and text overlap

### DIFF
--- a/src/components/operations/operation-list/ko/runtime/operation-list.html
+++ b/src/components/operations/operation-list/ko/runtime/operation-list.html
@@ -101,7 +101,7 @@
                 <a href="#" role="listitem" class="nav-link"
                     data-bind="attr: { href: $component.getReferenceUrl(item)}, css: { 'nav-link-active': $component.selectedOperationName() === item.name }">
                     <div class="row">
-                        <span class="col-md-2 mw-100" data-bind="attr: { 'data-method': method }"></span>
+                        <span class="col-md-2 mw-60" data-bind="attr: { 'data-method': method }"></span>
                         <span class="col-md-9" data-bind="text: ($component.showUrlPath() ? item.urlTemplate : item.displayName), css: { 'text-truncate': !$component.wrapText(), 'text-wrap': $component.wrapText() }, attr: { title: ($component.showUrlPath() ? item.urlTemplate : item.displayName) }"></span>
                     </div>
                 </a>

--- a/src/components/operations/operation-list/ko/runtime/operation-list.html
+++ b/src/components/operations/operation-list/ko/runtime/operation-list.html
@@ -14,7 +14,7 @@
 
 <!-- ko ifnot: apiType() === 'websocket' || apiType() === 'graphql'-->
 <div class="form-inline search-input">
-    <div class="d-block flex-grow mw-100">
+    <div class="d-block flex-grow mw-170">
         <div class="input-group">
             <input type="search" aria-label="Search operations" placeholder="Search operations" spellcheck="false" data-bind="textInput: pattern" />
             <button type="button" class="search-button" aria-label="Search operations">
@@ -64,7 +64,7 @@
                 <a href="#" role="listitem" class="nav-link"
                     data-bind="attr: { href: $component.getReferenceUrl(item) }, css: { 'nav-link-active': $component.selectedOperationName() === item.name }">
                     <div class="row">
-                        <span class="col-md-2" data-bind="attr: { 'data-method': method }"></span>
+                        <span class="col-md-2 mw-60" data-bind="attr: { 'data-method': method }"></span>
                         <span class="col-md-9" data-bind="text: ($component.showUrlPath() ? item.urlTemplate : item.displayName), css: { 'text-truncate': !$component.wrapText(), 'text-wrap': $component.wrapText() }, attr: { title: ($component.showUrlPath() ? item.urlTemplate : item.displayName) }"></span>
                     </div>
                 </a>
@@ -101,7 +101,7 @@
                 <a href="#" role="listitem" class="nav-link"
                     data-bind="attr: { href: $component.getReferenceUrl(item)}, css: { 'nav-link-active': $component.selectedOperationName() === item.name }">
                     <div class="row">
-                        <span class="col-md-2" data-bind="attr: { 'data-method': method }"></span>
+                        <span class="col-md-2 mw-100" data-bind="attr: { 'data-method': method }"></span>
                         <span class="col-md-9" data-bind="text: ($component.showUrlPath() ? item.urlTemplate : item.displayName), css: { 'text-truncate': !$component.wrapText(), 'text-wrap': $component.wrapText() }, attr: { title: ($component.showUrlPath() ? item.urlTemplate : item.displayName) }"></span>
                     </div>
                 </a>

--- a/src/components/users/subscriptions/ko/runtime/subscriptions.html
+++ b/src/components/users/subscriptions/ko/runtime/subscriptions.html
@@ -74,7 +74,7 @@
                         <div role="rowheader" class="col-md-3">
                             Primary key
                         </div>
-                        <div role="cell" class="col-md-6">
+                        <div role="cell" class="col-md-6 text-wrap">
                             <code data-bind="text: primaryKey"></code>
                         </div>
                         <div role="cell" class="col-md-3 nowrap">
@@ -97,7 +97,7 @@
 
                     <div role="row" class="row">
                         <div role="rowheader" class="col-md-3">Secondary key</div>
-                        <div role="cell" class="col-md-6">
+                        <div role="cell" class="col-md-6 text-wrap">
                             <code data-bind="text: secondaryKey"></code>
                         </div>
                         <div role="cell" class="col-md-3 nowrap">

--- a/src/themes/website/styles/forms.scss
+++ b/src/themes/website/styles/forms.scss
@@ -235,12 +235,12 @@ $search-button-width: 30px;
     tag-input {
         display: block;
         margin: 5px 0;
-        width: 300px;
+        max-width: 300px;
     }
 
     .input-group:first-child {
         border-bottom: 1px solid #a19f9d;
-        width: 300px;
+        max-width: 300px;
         flex: 1;
     }
 

--- a/src/themes/website/styles/utils.scss
+++ b/src/themes/website/styles/utils.scss
@@ -94,3 +94,11 @@
     overflow-y: auto;
     scroll-behavior: smooth;
 }
+
+.mw-60 {
+    min-width: 60px;
+}
+
+.mw-170 {
+    min-width: 170px;
+}


### PR DESCRIPTION
Fixes #1380

Cards - Cannot reproduce with provided information. I used zoom value provided in issue every think looks ok. I tried many different resolutions and zoom settings and cannot find a case in which problem occurs.

Operation Details - fixed, see screen below
Zoom 150%
![image](https://user-images.githubusercontent.com/14052586/142628203-8dfb5dfc-67bf-43b0-96c1-8ee857468d54.png)

Zoom 175%
![image](https://user-images.githubusercontent.com/14052586/142628372-0ceeb8eb-b80e-42ea-bb00-2179d834ea05.png)

Zoom 200%
![image](https://user-images.githubusercontent.com/14052586/142628692-9ee9ebd8-cfa2-4c6f-bd45-fa8a68052518.png)


User: Subscriptions - fixed, see screens below
Zoom 150%
![image](https://user-images.githubusercontent.com/14052586/142629335-9d10b33c-50b3-4a4e-ae62-a2dd823cffa3.png)

Zoom 175%
![image](https://user-images.githubusercontent.com/14052586/142629398-e5c10f5c-962e-4e1d-ae19-8797af61ef92.png)

Zoom 200%
![image](https://user-images.githubusercontent.com/14052586/142629491-e6710524-0d38-4a16-a78e-29098838f32b.png)

Zoom 250%
![image](https://user-images.githubusercontent.com/14052586/142629559-be55fb3c-a52c-42a7-9fb9-7056f9253185.png)

