### PR TITLE
Fixed: by default, the cod sample should have the secrets hidden

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/authorization.ts
+++ b/src/components/operations/operation-details/ko/runtime/authorization.ts
@@ -188,12 +188,12 @@ export class Authorization {
 
         const keyHeader = new ConsoleHeader();
         keyHeader.name(subscriptionKeyHeaderName);
-        keyHeader.value(subscriptionKey);
         keyHeader.description = "Subscription key.";
         keyHeader.secret = true;
         keyHeader.inputTypeValue("password");
         keyHeader.type = "string";
         keyHeader.required = true;
+        keyHeader.value(subscriptionKey);
 
         if(!this.isGraphQL()) {
             this.consoleOperation().request.headers.push(keyHeader);


### PR DESCRIPTION
Related issue: #1436