### PR TITLE
An optional flag to publish changes post importing using scripts.v3/generate.js

### DIFF
--- a/scripts.v3/generate.js
+++ b/scripts.v3/generate.js
@@ -45,6 +45,12 @@ const yargs = require('yargs')
         example: '../dist/snapshot',
         demandOption: false
     })
+    .option('publish', {
+        type: 'boolean',
+        default: false,
+        description: 'Enabling this flag will publish the developer portal changes.',
+        demandOption: false
+    })
     .help()
     .argv;
 
@@ -68,6 +74,14 @@ async function generate() {
     );
 
     await importerExporter.import();
+
+    if (yargs.publish === true) {
+        console.log("Publishing changes...");
+        await importerExporter.publish();
+        console.log("Published.");
+    } else {
+        console.warn("Skipped publishing changes! If you want to publish the changes run the script with --publish true flag.");    
+    }
 }
 
 generate()

--- a/scripts.v3/generate.js
+++ b/scripts.v3/generate.js
@@ -12,7 +12,8 @@
  *    node ./cleanup ^
  *   --subscriptionId < your subscription ID > ^
  *   --resourceGroupName < your resource group name > ^
- *   --serviceName < your service name >
+ *   --serviceName < your service name > ^
+ *   --publish true [false: default]
  */
 
 const path = require("path");


### PR DESCRIPTION
This PR adds an extra flag to the `scripts.v3/generate.js` to optionally publish the changes after importing.

This non-mandatory optional flag defaults to false, making it backward compatible with current usage.

[Discussion: Automatic Publishing API-M with Generate](https://github.com/Azure/api-management-developer-portal/discussions/1671)