### PR TITLE
Fix AAD/B2C message shown on SignUp page error

### DIFF
--- a/src/components/users/signup-social/ko/signupSocial.html
+++ b/src/components/users/signup-social/ko/signupSocial.html
@@ -2,7 +2,7 @@
 <signup-social-runtime data-bind="attr: { params: runtimeConfig }"></signup-social-runtime>
 <!-- /ko -->
 
-<!-- ko ifnot: identityProvider && (mode === "publishing") -->
+<!-- ko if: showNoAadConfigMessage -->
 <div class="not-configured">This widget will display a sign-up form when you configure <a
         href="https://aka.ms/apim-how-to-aad" target="_blank">Azure Active Directory</a> or<a
         href="https://aka.ms/apim-how-to-aadb2c" target="_blank">Azure Active Directory B2C</a> integration in your API

--- a/src/components/users/signup-social/ko/signupSocialViewModel.ts
+++ b/src/components/users/signup-social/ko/signupSocialViewModel.ts
@@ -10,10 +10,12 @@ export class SignupSocialViewModel {
     public readonly identityProvider: ko.Observable<boolean>;
     public readonly mode: ko.Observable<string>;
     public readonly runtimeConfig: ko.Observable<string>;
+    public readonly showNoAadConfigMessage: ko.Computed<boolean>;
 
     constructor() {
         this.identityProvider = ko.observable<boolean>();
         this.mode = ko.observable<string>();
         this.runtimeConfig = ko.observable<string>();
+        this.showNoAadConfigMessage = ko.computed<boolean>(() => !this.identityProvider() && this.mode() !== "publishing"); 
     }
 }


### PR DESCRIPTION
Fix No AAD/B2C configured message shown on SignUp page when an identity provider was indeed configured. The bug was caused by a type comparison error between `Observable<string>` and `string` in `signupSocial.html`.
Fix inspired by #1621

Closes #1686