### PR TITLE
Add "API: Products (dropdown)" widget

### DIFF
--- a/src/apim.runtime.module.ts
+++ b/src/apim.runtime.module.ts
@@ -20,6 +20,7 @@ import "./bindingHandlers/scrollintoview";
 import "./bindingHandlers/syntaxHighlight";
 import "./bindingHandlers/tab";
 import { ApiProducts } from "./components/apis/api-products/ko/runtime/api-products";
+import { ApiProductsDropdown } from "./components/apis/api-products/ko/runtime/api-products-dropdown";
 import { ApiProductsTiles } from "./components/apis/api-products/ko/runtime/api-products-tiles";
 import { ApiDetails } from "./components/apis/details-of-api/ko/runtime/api-details";
 import { ApiHistory } from "./components/apis/history-of-api/ko/runtime/api-history";
@@ -96,6 +97,7 @@ export class ApimRuntimeModule implements IInjectorModule {
         injector.bind("apiListDropdown", ApiListDropdown);
         injector.bind("apiListTiles", ApiListTiles);
         injector.bind("apiProducts", ApiProducts);
+        injector.bind("apiProductsDropdown", ApiProductsDropdown);
         injector.bind("apiProductsTiles", ApiProductsTiles);
         injector.bind("apiDetails", ApiDetails);
         injector.bind("apiHistory", ApiHistory);

--- a/src/components/apis/api-products/apiProductsContract.ts
+++ b/src/components/apis/api-products/apiProductsContract.ts
@@ -6,7 +6,7 @@ import { HyperlinkContract } from "@paperbits/common/editing";
  */
 export interface ApiProductsContract extends Contract {
     /**
-     * List layout. "list" or "tiles"
+     * List layout. "list", "dropdown" or "tiles"
      */
     itemStyleView?: string;
 

--- a/src/components/apis/api-products/apiProductsHandlers.ts
+++ b/src/components/apis/api-products/apiProductsHandlers.ts
@@ -16,6 +16,21 @@ export class ApiProductsHandlers implements IWidgetHandler {
     }
 }
 
+export class ApiProductsDropdownHandlers implements IWidgetHandler {
+  public async getWidgetOrder(): Promise<IWidgetOrder> {
+    const widgetOrder: IWidgetOrder = {
+      name: "api-products-dropdown",
+      category: "APIs",
+      displayName: "API: Products (dropdown)",
+      iconClass: "widget-icon widget-icon-api-management",
+      requires: ["html"],
+      createModel: async () => new ApiProductsModel("dropdown"),
+    };
+
+    return widgetOrder;
+  }
+}
+
 export class ApiProductsTilesHandlers implements IWidgetHandler {
     public async getWidgetOrder(): Promise<IWidgetOrder> {
         const widgetOrder: IWidgetOrder = {

--- a/src/components/apis/api-products/apiProductsModel.ts
+++ b/src/components/apis/api-products/apiProductsModel.ts
@@ -5,7 +5,7 @@ import { HyperlinkModel } from "@paperbits/common/permalinks";
  */
 export class ApiProductsModel {
     /**
-     * List layout. "list" or "tiles"
+     * List layout. "list", "dropdown" or "tiles"
      */
     public layout?: string;
 
@@ -14,7 +14,7 @@ export class ApiProductsModel {
      */
     public detailsPageHyperlink: HyperlinkModel;
 
-    constructor(layout?: "list"|"tiles") {
+    constructor(layout?: "list"|"dropdown"|"tiles") {
         this.layout = layout;
     }
 }

--- a/src/components/apis/api-products/ko/apiProducts.html
+++ b/src/components/apis/api-products/ko/apiProducts.html
@@ -2,6 +2,10 @@
 <api-products-runtime data-bind="attr: { params: runtimeConfig }"></api-products-runtime>
 <!-- /ko -->
 
+<!-- ko if: layout() === 'dropdown' -->
+<api-products-dropdown-runtime data-bind="attr: { params: runtimeConfig }"></api-products-dropdown-runtime>
+<!-- /ko -->
+
 <!-- ko if: layout() === 'tiles' -->
 <api-products-tiles-runtime data-bind="attr: { params: runtimeConfig }"></api-products-tiles-runtime>
 <!-- /ko -->

--- a/src/components/apis/api-products/ko/apiProductsEditor.module.ts
+++ b/src/components/apis/api-products/ko/apiProductsEditor.module.ts
@@ -1,11 +1,12 @@
 import { IInjectorModule, IInjector } from "@paperbits/common/injection";
-import { ApiProductsHandlers, ApiProductsTilesHandlers } from "../apiProductsHandlers";
+import { ApiProductsHandlers, ApiProductsDropdownHandlers, ApiProductsTilesHandlers } from "../apiProductsHandlers";
 import { ApiProductsEditor } from "./apiProductsEditor";
 
 export class ApiProductsEditorModule implements IInjectorModule {
     public register(injector: IInjector): void {
         injector.bind("apiProductsEditor", ApiProductsEditor);
         injector.bindToCollection("widgetHandlers", ApiProductsHandlers, "apiProductsHandlers");
+        injector.bindToCollection("widgetHandlers", ApiProductsDropdownHandlers, "apiProductsDropdownHandlers");
         injector.bindToCollection("widgetHandlers", ApiProductsTilesHandlers, "apiProductsTilesHandlers");
     }
 }

--- a/src/components/apis/api-products/ko/runtime/api-products-dropdown.html
+++ b/src/components/apis/api-products/ko/runtime/api-products-dropdown.html
@@ -1,0 +1,42 @@
+<div class="form-group">
+    <div class="input-group">
+        <div class="form-control" tabindex="0" role="button" aria-label="Products" data-toggle="dropdown">
+            <span data-bind="text: selection"></span>
+        </div>
+        <button class="input-group-addon no-border" data-toggle="dropdown" aria-label="Expand products list">
+            <i class="icon-emb icon-emb-chevron-down"></i>
+        </button>
+        <div class="dropdown">
+            <div class="form-group">
+                <input type="search" class="form-control form-control-light" aria-label="Search"
+                    placeholder="Search products" spellcheck="false" data-bind="textInput: pattern" />
+            </div>
+
+            <div class="menu menu-vertical" role="list">
+                <!-- ko if: working -->
+                <spinner class="block" role="presentation"></spinner>
+                <!-- /ko -->
+
+                <!-- ko ifnot: working -->
+
+                <!-- ko foreach: { data: products, as: 'product' } -->
+                <a href="#" role="listitem" class="nav-link text-truncate" data-dismiss
+                    data-bind="attr: { href: $component.getProductUrl(product) }, text: product.displayName, css: { 'nav-link-active': $component.selectedProduct() === product }"></a>
+                <!-- /ko -->
+
+                <!-- ko if: products().length === 0 -->
+                <p>No products found</p>
+                <!-- /ko -->
+
+                <!-- ko ifnot: working -->
+                <!-- ko if: $component.totalPages() > 1 -->
+                <pagination params="{ pageNumber: $component.pageNumber, totalPages: $component.totalPages }">
+                </pagination>
+                <!-- /ko -->
+                <!-- /ko -->
+
+                <!-- /ko -->
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/components/apis/api-products/ko/runtime/api-products-dropdown.ts
+++ b/src/components/apis/api-products/ko/runtime/api-products-dropdown.ts
@@ -1,0 +1,144 @@
+import * as ko from "knockout";
+import * as Constants from "../../../../../constants";
+import template from "./api-products-dropdown.html";
+import { Component, RuntimeComponent, OnMounted, Param, OnDestroyed } from "@paperbits/common/ko/decorators";
+import { Router } from "@paperbits/common/routing";
+import { ApiService } from "../../../../../services/apiService";
+import { SearchQuery } from "../../../../../contracts/searchQuery";
+import { RouteHelper } from "../../../../../routing/routeHelper";
+import { Product } from "../../../../../models/product";
+
+@RuntimeComponent({
+  selector: "api-products-dropdown-runtime",
+})
+@Component({
+  selector: "api-products-dropdown-runtime",
+  template: template,
+})
+export class ApiProductsDropdown {
+  public readonly products: ko.ObservableArray<Product>;
+  public readonly selectedApiName: ko.Observable<string>;
+  public readonly working: ko.Observable<boolean>;
+  public readonly pattern: ko.Observable<string>;
+  public readonly pageNumber: ko.Observable<number>;
+  public readonly totalPages: ko.Observable<number>;
+  public readonly selectedProduct: ko.Observable<Product>;
+  public readonly selectedProductName: ko.Observable<string>;
+  public readonly selection: ko.Computed<string>;
+
+  constructor(
+    private readonly apiService: ApiService,
+    private readonly router: Router,
+    private readonly routeHelper: RouteHelper
+  ) {
+    this.detailsPageUrl = ko.observable();
+    this.allowSelection = ko.observable(false);
+    this.products = ko.observableArray([]);
+    this.selectedApiName = ko.observable();
+    this.working = ko.observable();
+    this.pattern = ko.observable();
+    this.pageNumber = ko.observable(1);
+    this.totalPages = ko.observable(0);
+    this.selectedProduct = ko.observable();
+    this.selectedProductName = ko.observable();
+    this.selection = ko.computed(() => {
+        const product = ko.unwrap(this.selectedProduct);
+        return product ? product.displayName : "Select API: products";
+    });
+  }
+
+  @Param()
+  public allowSelection: ko.Observable<boolean>;
+  
+  @Param()
+  public detailsPageUrl: ko.Observable<string>;
+
+  @OnMounted()
+  public async initialize(): Promise<void> {
+    const apiName = this.routeHelper.getApiName();
+
+    if (apiName) {
+      this.selectedApiName(apiName);
+      await this.loadPageOfProducts();
+    }
+
+    await this.resetSearch();
+
+    this.pattern
+    .extend({ rateLimit: { timeout: Constants.defaultInputDelayMs, method: "notifyWhenChangesStop" } })
+    .subscribe(this.resetSearch);
+
+    this.router.addRouteChangeListener(this.onRouteChange);
+    this.pageNumber.subscribe(this.loadPageOfProducts);
+  }
+
+  /**
+   * Initiates searching products.
+   */
+   public async resetSearch(): Promise<void> {
+        this.pageNumber(1);
+        this.loadPageOfProducts();
+    }
+
+  private async onRouteChange(): Promise<void> {
+    const apiName = this.routeHelper.getApiName();
+
+    if (
+      !apiName ||
+      (apiName === this.selectedApiName())
+    ) {
+      await this.resetSearch();
+      return;
+    }
+
+    this.selectedApiName(apiName);
+    await this.loadPageOfProducts();
+
+    await this.resetSearch();
+  }
+
+  /**
+   * Loads page of products.
+   */
+  public async loadPageOfProducts(): Promise<void> {
+    try {
+        this.working(true);
+
+        const pageNumber = this.pageNumber() - 1;
+
+        const query: SearchQuery = {
+            pattern: this.pattern(),
+            skip: pageNumber * Constants.defaultPageSize,
+            take: Constants.defaultPageSize
+        };
+      
+      const apiName = this.selectedApiName();
+
+      const pageOfProducts = await this.apiService.getApiProductsPage(apiName, query);
+
+      this.products(pageOfProducts.value);
+      this.totalPages(Math.ceil(pageOfProducts.count / Constants.defaultPageSize));
+
+      const productName = this.routeHelper.getProductName();
+
+        this.selectedProduct(productName
+            ? pageOfProducts.value.find(item => item.id.endsWith(productName))
+            : pageOfProducts.value[-1]);
+    }
+    catch (error) {
+        throw new Error(`Unable to load API Products. Error: ${error.message}`);
+    }
+    finally {
+        this.working(false);
+    }
+  }
+
+    public getProductUrl(product: Product): string {
+        return this.routeHelper.getProductReferenceUrl(product.name, this.detailsPageUrl());
+    }
+
+    @OnDestroyed()
+    public dispose(): void {
+        this.router.removeRouteChangeListener(this.onRouteChange);
+    }
+}

--- a/src/components/apis/api-products/ko/runtime/api-products-dropdown.ts
+++ b/src/components/apis/api-products/ko/runtime/api-products-dropdown.ts
@@ -59,7 +59,6 @@ export class ApiProductsDropdown {
 
     if (apiName) {
       this.selectedApiName(apiName);
-      await this.loadPageOfProducts();
     }
 
     await this.resetSearch();

--- a/src/components/apis/api-products/ko/runtime/api-products-dropdown.ts
+++ b/src/components/apis/api-products/ko/runtime/api-products-dropdown.ts
@@ -121,9 +121,9 @@ export class ApiProductsDropdown {
 
       const productName = this.routeHelper.getProductName();
 
-        this.selectedProduct(productName
-            ? pageOfProducts.value.find(item => item.id.endsWith(productName))
-            : pageOfProducts.value[-1]);
+            if(productName){
+                this.selectedProduct(pageOfProducts.value.find(item => item.id.endsWith(productName)));
+             }
     }
     catch (error) {
         throw new Error(`Unable to load API Products. Error: ${error.message}`);


### PR DESCRIPTION
## 🎩 Goal
Create a new widget to display in a dropdown format the products assigned to a specific API within the Developer Portal. Currently there are two widgets accomplishing this action (list and tiles) but the dropdown view was missing.

## 🗿 In the mid time
This feature was implemented by following the rules of the already existing widgets List of APIs (dropdown) and List of products (dropdown). So you can expect the same dropdown behavior (including the search within the dropdown option).

## 🔎 End-to-end test
### Widget selector
<img src="https://i.ibb.co/rMbv746/screen1.png" alt="drawing" width="400"/>

### Widget selected

<img src="https://i.ibb.co/2sh8yQ8/screen2.png" alt="drawing" width="400"/>

### Widget dropdown

<img src="https://i.ibb.co/NSfFvPS/screen3.png" alt="drawing" width="400"/>

### Widget filter

<img src="https://i.ibb.co/X75cFMY/screen4.png" alt="drawing" width="400"/>

### Widget filter selected

<img src="https://i.ibb.co/hV2bzJB/screen5.png" alt="drawing" width="400"/>

Closes #1177