### PR TITLE
custom-html widget iframe allow more attributes

### DIFF
--- a/src/components/custom-html/ko/customHtmlView.html
+++ b/src/components/custom-html/ko/customHtmlView.html
@@ -1,4 +1,3 @@
-<iframe data-bind="attr: { srcdoc: htmlCode }, styled: styles"
-    sandbox="allow-scripts allow-modals allow-forms"
+<iframe data-bind="attr: { srcdoc: htmlCode, sandbox: iframeSandboxAllows }, styled: styles"
     frameborder="0"
 ></iframe>

--- a/src/components/custom-html/ko/customHtmlViewModel.ts
+++ b/src/components/custom-html/ko/customHtmlViewModel.ts
@@ -3,6 +3,7 @@ import template from "./customHtmlView.html";
 import { widgetSelector } from "../constants";
 import { Component } from "@paperbits/common/ko/decorators";
 import { StyleModel } from "@paperbits/common/styles";
+import { iframeSandboxAllows } from "../../../constants";
 
 @Component({
     selector: widgetSelector,
@@ -11,6 +12,7 @@ import { StyleModel } from "@paperbits/common/styles";
 export class CustomHtmlViewModel {
     public readonly styles: ko.Observable<StyleModel>;
     public readonly htmlCode: ko.Observable<string>;
+    public readonly iframeSandboxAllows: string = iframeSandboxAllows;
 
     constructor() {
         this.htmlCode = ko.observable();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -267,3 +267,8 @@ export const genericHttpRequestError = "Server error. Unable to send request. Pl
 
 export const oauthSessionKey = "oauthSession";
 export const reservedCharTuplesForOData: [string, string][] = [["'", "''"]];
+
+/**
+ * List of allowed attributes for a sandboxed iframe.
+ */
+export const iframeSandboxAllows = "allow-scripts allow-modals allow-forms allow-downloads allow-popups-to-escape-sandbox allow-top-navigation allow-presentation allow-orientation-lock allow-pointer-lock";


### PR DESCRIPTION
### The problem
> Customer is using a widget with custom HTML code. The code of custom-html widget seems to end up in an iframe. The iframe seems to miss sandbox='allow-popups-to-escape-sandbox' which seems to stop the browser from opening up a link in a new tab. Also the code is provided inline which makes the browser think it doesn't have the same origin as the parent page, so customer can't use JavaScript to open a new page in the parent window either.

### The solution
I've added following attributes:
```
allow-popups-to-escape-sandbox 
allow-top-navigation 
allow-presentation 
allow-orientation-lock 
allow-pointer-lock
allow-downloads 
```
I made it as a separate constant so it can be reused elsewhere, for example custom widget iframes.