### PR TITLE
Removed duplicated call to /apis for the API list widget

### DIFF
--- a/src/components/apis/list-of-apis/ko/runtime/api-list-dropdown.ts
+++ b/src/components/apis/list-of-apis/ko/runtime/api-list-dropdown.ts
@@ -58,7 +58,6 @@ export class ApiListDropdown {
 
     @OnMounted()
     public async initialize(): Promise<void> {
-        await this.resetSearch();
         await this.checkSelection();
 
         this.pattern

--- a/src/components/apis/list-of-apis/ko/runtime/api-list-tiles.ts
+++ b/src/components/apis/list-of-apis/ko/runtime/api-list-tiles.ts
@@ -62,8 +62,6 @@ export class ApiListTiles {
         this.groupByTag(this.defaultGroupByTagToEnabled());
         this.tags.subscribe(this.resetSearch);
 
-        await this.resetSearch();
-
         this.pattern
             .extend({ rateLimit: { timeout: Constants.defaultInputDelayMs, method: "notifyWhenChangesStop" } })
             .subscribe(this.resetSearch);

--- a/src/components/apis/list-of-apis/ko/runtime/api-list.ts
+++ b/src/components/apis/list-of-apis/ko/runtime/api-list.ts
@@ -62,8 +62,6 @@ export class ApiList {
         this.groupByTag(this.defaultGroupByTagToEnabled());
         this.tags.subscribe(this.resetSearch);
 
-        await this.resetSearch();
-
         this.pattern
             .extend({ rateLimit: { timeout: Constants.defaultInputDelayMs, method: "notifyWhenChangesStop" } })
             .subscribe(this.resetSearch);

--- a/src/components/tag-input/tag-input.ts
+++ b/src/components/tag-input/tag-input.ts
@@ -65,6 +65,7 @@ export class TagInput {
         const tagsValue = this.routeHelper.getTags();
 
         if (!tagsValue) {
+            this.onChange([]);
             return;
         }
 


### PR DESCRIPTION
### **Problem:**
When loading the API list widget, there is a double call made to /apis.
In case the APIs are filtered after a tag, one of the calls will get and show the list with all the APIs and only the second one will get and show the filtered list of APIs:
![image](https://user-images.githubusercontent.com/92857141/160422658-79a06fad-ffc1-46e1-ae87-51a6041ba853.png)

The problem was that the components that used the component tag-input, during the initialization, were calling `loadPageOfApis()` twice: 
- once by a direct call from the `resetSearch()` method
- once by a subscription notification that the tags were changed

For the second call, the notification was only sent after the tag-input component finished loading and the tag list was populated. In case there was no filter applied to the API list, this notification was not send and so the `resetSearch()` call was needed.

### **Solution:**
Notify the components that use tag-filter that the tag list was loaded (also when it is empty), so they can make the call to retrieve the API list accordingly
Remove the direct call to `resetSearch()` from the initialization.
