### PR TITLE
Hide "subscribe" button when subscriptions are pending

### DIFF
--- a/src/components/products/product-subscribe/ko/runtime/product-subscribe.ts
+++ b/src/components/products/product-subscribe/ko/runtime/product-subscribe.ts
@@ -119,7 +119,7 @@ export class ProductSubscribe {
     private async loadSubscriptions(userId: string): Promise<void> {
         const product = this.product();
         const subscriptions = await this.productService.getSubscriptionsForProduct(userId, product.id);
-        const activeSubscriptions = subscriptions.value.filter(item => item.state === SubscriptionState.active) || [];
+        const activeSubscriptions = subscriptions.value.filter(item => item.state === SubscriptionState.active || item.state === SubscriptionState.submitted) || [];
         const numberOfSubscriptions = activeSubscriptions.length;
         const limitReached = (product.subscriptionsLimit || product.subscriptionsLimit === 0) && product.subscriptionsLimit <= numberOfSubscriptions;
         this.limitReached(limitReached);


### PR DESCRIPTION
**Problem**
If the limit of subscriptions is reached, but they are not all in approved state, the user can still try to create a new subscription; the request will fail but there is no error shown and the "subscribe" button is still visible to the user.

**Solution**
Show the text for subscriptions limit reached even if the subscriptions are in "submitted" state.