### PR TITLE
Fixed: default schema view combobox gets dismissed

### DIFF
--- a/src/components/operations/operation-details/ko/operationDetailsEditor.html
+++ b/src/components/operations/operation-details/ko/operationDetailsEditor.html
@@ -1,4 +1,4 @@
-<fieldset class="form flex-item flex-item-grow" data-bind="scrollable: {}">
+<div class="form flex-item flex-item-grow" data-bind="scrollable: {}">
     <div class="form-group form-group-collapsible">
         <label class="form-label">
             <a href="#" class="form-group-toggle" title="Toggle section"
@@ -40,10 +40,10 @@
                     Default schema view
                 </label>
                 <select id="defaultSchemaView" class="form-control" data-bind="value: defaultSchemaView">
-                    <option value="table">Table</value>
-                    <option value="raw">Raw schema</value>
+                    <option value="table">Table</option>
+                    <option value="raw">Raw schema</option>
                 </select>
             </div>
         </div>
     </div>
-</fieldset>
+</div>


### PR DESCRIPTION
The `<fieldset>` tag causes the `<select>` to close immediately after opening.