### PR TITLE
Fixed wildcard operation path behavior

### DIFF
--- a/src/models/console/consoleOperation.ts
+++ b/src/models/console/consoleOperation.ts
@@ -42,6 +42,12 @@ export class ConsoleOperation {
             this.responses = [];
         }
 
+        if (this.urlTemplate.includes("/*")) {
+            const templateParameter = new ConsoleParameter();
+            templateParameter.name("*");
+            this.templateParameters.push(templateParameter);
+        }
+
         this.requestUrl = ko.computed(() => {
             const protocol = this.api.protocols.indexOf("https") !== -1 ? "https" : "http";
             const urlTemplate = this.getRequestPath();
@@ -124,8 +130,9 @@ export class ConsoleOperation {
         if (this.api.apiVersionSet && this.api.apiVersionSet.versioningScheme === "Query") {
             requestUrl = this.addParam(requestUrl, this.api.apiVersionSet.versionQueryName, this.api.apiVersion);
         }
+        requestUrl = requestUrl.replace("/*", "");
 
         return `${this.api.path}${versionPath}${requestUrl}`;
     }
-    
+
 }

--- a/src/models/operation.ts
+++ b/src/models/operation.ts
@@ -54,6 +54,6 @@ export class Operation {
             })
             .join("");
 
-        this.displayUrlTemplate = `${this.urlTemplate}${optionalQueryParameters}`;
+        this.displayUrlTemplate = `${this.urlTemplate.replace("/*","")}${optionalQueryParameters}`;
     }
 }


### PR DESCRIPTION
## Problem:
If there is an operation with the path `/*`, the test console will add the `*` to the end of the request path
![image](https://user-images.githubusercontent.com/92857141/171408905-16f4e5ae-2de1-4c90-af83-920f11e009d7.png)

Because of this, there is no way to define a wildcard operation that hits the root of the API. Also, by adding the `*` at the end of the request path, after sending the request, the response is a 400 error, thus there is no way to test this operation.

## Solution:
- If the operation path is `/*`, there will be a template parameter added by default in the test console (which doesn't have a required value):
![image](https://user-images.githubusercontent.com/92857141/171409793-d30778c2-d542-488c-8397-2f2ba5f15e24.png)

- If there is no value provided, the path will be displayed and used without any additional characters:
![image](https://user-images.githubusercontent.com/92857141/171410120-5823052d-06b8-4e5f-b412-686250ac525b.png)

- If there is a value added for this parameter, this will be added at the end of the request path:
![image](https://user-images.githubusercontent.com/92857141/171409991-375c5692-a487-4cf9-8c4f-d05165b09f73.png)


