### PR TITLE
Add top param for document content type

### DIFF
--- a/scripts.v3/utils.js
+++ b/scripts.v3/utils.js
@@ -169,8 +169,9 @@ class ImporterExporter {
         try {
             const contentItems = [];
             let nextPageUrl = `/contentTypes/${contentType}/contentItems`;
+            nextPageUrl = this.ensureDocumentTypeFiltered(contentType, nextPageUrl);
 
-            do {
+            do {                
                 const data = await this.httpClient.sendRequest("GET", nextPageUrl);
                 contentItems.push(...data.value);
 
@@ -187,6 +188,15 @@ class ImporterExporter {
         catch (error) {
             throw new Error(`Unable to fetch content items. ${error.message}`);
         }
+    }
+
+    ensureDocumentTypeFiltered(contentType, nextLink)
+    {
+        if(contentType === 'document')
+        {
+            nextLink = `${nextLink}?$top=1` 
+        }
+        return nextLink
     }
 
     /**

--- a/scripts.v3/utils.js
+++ b/scripts.v3/utils.js
@@ -171,7 +171,7 @@ class ImporterExporter {
             let nextPageUrl = `/contentTypes/${contentType}/contentItems`;
             nextPageUrl = this.ensureDocumentTypeFiltered(contentType, nextPageUrl);
 
-            do {                
+            do {
                 const data = await this.httpClient.sendRequest("GET", nextPageUrl);
                 contentItems.push(...data.value);
 
@@ -190,11 +190,9 @@ class ImporterExporter {
         }
     }
 
-    ensureDocumentTypeFiltered(contentType, nextLink)
-    {
-        if(contentType === 'document')
-        {
-            nextLink = `${nextLink}?$top=1` 
+    ensureDocumentTypeFiltered(contentType, nextLink) {
+        if (contentType === 'document') {
+            nextLink = `${nextLink}?$top=1`
         }
         return nextLink
     }


### PR DESCRIPTION
During the migration, in some cases fetching document typed content items exceed ARM limit (15728640 bytes). As a result, ARM returns a 502 to the caller and it fails. 

Added paging for document typed content items.