### PR TITLE
Removed unneccessary focus from widget editors

### DIFF
--- a/src/components/apis/api-products/ko/apiProductsEditor.html
+++ b/src/components/apis/api-products/ko/apiProductsEditor.html
@@ -6,7 +6,7 @@
                 data-bind="tooltip: 'A link to be navigated on click.'"></button>
         </label>
         <div class="input-group">
-            <input id="hyperlink" type="text" class="form-control" readonly data-bind="value: hyperlinkTitle" />
+            <input id="hyperlink" type="text" class="form-control" disabled data-bind="value: hyperlinkTitle" />
             <button class="btn input-group-addon" title="Select hyperlink" aria-label="Select hyperlink"
                 data-bind="balloon: { position: 'right', component: { name: 'hyperlink-selector', params: { hyperlink: $component.hyperlink, onChange: $component.onHyperlinkChange } } }">
                 <i class="paperbits-icon paperbits-link-69-2"></i>

--- a/src/components/apis/details-of-api/ko/detailsOfApiEditor.html
+++ b/src/components/apis/details-of-api/ko/detailsOfApiEditor.html
@@ -8,7 +8,7 @@
                 data-bind="tooltip: 'A link to be navigated on click.'"></button>
         </div>
         <div class="input-group">
-            <input id="hyperlink" type="text" class="form-control" readonly data-bind="value: hyperlinkTitle" />
+            <input id="hyperlink" type="text" class="form-control" disabled data-bind="value: hyperlinkTitle" />
             <button class="btn input-group-addon" title="Select hyperlink" aria-label="Select hyperlink"
                 data-bind="balloon: { position: 'right', component: { name: 'hyperlink-selector', params: { hyperlink: $component.hyperlink, onChange: $component.onHyperlinkChange } } }">
                 <i class="paperbits-icon paperbits-link-69-2"></i>

--- a/src/components/apis/history-of-api/ko/historyOfApiEditor.html
+++ b/src/components/apis/history-of-api/ko/historyOfApiEditor.html
@@ -6,7 +6,7 @@
                 data-bind="tooltip: 'A link to be navigated on click.'"></button>
         </label>
         <div class="input-group">
-            <input id="hyperlink" type="text" class="form-control" readonly data-bind="value: hyperlinkTitle" />
+            <input id="hyperlink" type="text" class="form-control" disabled data-bind="value: hyperlinkTitle" />
             <button class="btn input-group-addon" title="Select hyperlink" aria-label="Select hyperlink"
                 data-bind="balloon: { position: 'right', component: { name: 'hyperlink-selector', params: { hyperlink: $component.hyperlink, onChange: $component.onHyperlinkChange } } }">
                 <i class="paperbits-icon paperbits-link-69-2"></i>

--- a/src/components/apis/list-of-apis/ko/listOfApisEditor.html
+++ b/src/components/apis/list-of-apis/ko/listOfApisEditor.html
@@ -14,7 +14,8 @@
 
     <div class="form-group">
         <label for="defaultGroupByTagToEnabled" class="form-label">
-            <input type="checkbox" id="defaultGroupByTagToEnabled" name="defaultGroupByTagToEnabled" data-bind="checked: defaultGroupByTagToEnabled" />
+            <input type="checkbox" id="defaultGroupByTagToEnabled" name="defaultGroupByTagToEnabled"
+                data-bind="checked: defaultGroupByTagToEnabled" />
             Default Group by tag to enabled
         </label>
     </div>
@@ -24,12 +25,12 @@
             <label class="form-label">
                 Link to API details page
             </label>
-            <button class="btn btn-info" type="button" aria-hidden="true" role="tooltip" aria-label="A link to be navigated on click"
-                data-bind="tooltip: 'A link to be navigated on click.'">
+            <button class="btn btn-info" type="button" aria-hidden="true" role="tooltip"
+                aria-label="A link to be navigated on click" data-bind="tooltip: 'A link to be navigated on click.'">
             </button>
         </div>
         <div class="input-group">
-            <input id="hyperlink" class="form-control" readonly data-bind="value: hyperlinkTitle" />
+            <input type="text" id="hyperlink" class="form-control" disabled data-bind="value: hyperlinkTitle" />
             <button class="btn input-group-addon" aria-label="Select hyperlink"
                 data-bind="balloon: { position: 'right', component: { name: 'hyperlink-selector', params: { hyperlink: $component.hyperlink, onChange: $component.onHyperlinkChange } } }">
                 <i class="paperbits-icon paperbits-link-69-2"></i>

--- a/src/components/operations/operation-list/ko/operationListEditor.html
+++ b/src/components/operations/operation-list/ko/operationListEditor.html
@@ -40,7 +40,7 @@
                 data-bind="tooltip: 'A link to be navigated on click.'"></button>
         </label>
         <div class="input-group">
-            <input id="hyperlink" type="text" class="form-control" readonly data-bind="value: hyperlinkTitle" />
+            <input id="hyperlink" type="text" class="form-control" disabled data-bind="value: hyperlinkTitle" />
             <button class="btn input-group-addon" title="Select hyperlink" aria-label="Select hyperlink"
                 data-bind="balloon: { position: 'right', component: { name: 'hyperlink-selector', params: { hyperlink: $component.hyperlink, onChange: $component.onHyperlinkChange } } }">
                 <i class="paperbits-icon paperbits-link-69-2"></i>

--- a/src/components/products/product-apis/ko/productApisEditor.html
+++ b/src/components/products/product-apis/ko/productApisEditor.html
@@ -6,7 +6,7 @@
                 data-bind="tooltip: 'A link to be navigated on click.'"></button>
         </label>
         <div class="input-group">
-            <input id="hyperlink" type="text" class="form-control" readonly data-bind="value: hyperlinkTitle" />
+            <input id="hyperlink" type="text" class="form-control" disabled data-bind="value: hyperlinkTitle" />
             <button class="btn input-group-addon" title="Select hyperlink" aria-label="Select hyperlink"
                 data-bind="balloon: { position: 'right', component: { name: 'hyperlink-selector', params: { hyperlink: $component.hyperlink, onChange: $component.onHyperlinkChange } } }">
                 <i class="paperbits-icon paperbits-link-69-2"></i>

--- a/src/components/products/product-list/ko/productListEditor.html
+++ b/src/components/products/product-list/ko/productListEditor.html
@@ -13,7 +13,7 @@
                 data-bind="tooltip: 'A link to be navigated on click.'"></button>
         </label>
         <div class="input-group">
-            <input id="hyperlink" type="text" class="form-control" readonly data-bind="value: hyperlinkTitle" />
+            <input id="hyperlink" type="text" class="form-control" disabled data-bind="value: hyperlinkTitle" />
             <button class="btn input-group-addon" title="Select hyperlink" aria-label="Select hyperlink"
                 data-bind="balloon: { position: 'right', component: { name: 'hyperlink-selector', params: { hyperlink: $component.hyperlink, onChange: $component.onHyperlinkChange } } }">
                 <i class="paperbits-icon paperbits-link-69-2"></i>


### PR DESCRIPTION
When navigating with Tab key, the focus lands on the value from the input of the 'Link to...' in the widget editors. There is no action to be performed inside these inputs, thus they should not be focusable.

example (when focus lands on `APIs: Details` text):
![Unnecessaryfocus](https://user-images.githubusercontent.com/92857141/172416730-102a372f-d8ee-4404-9a06-d4ff4ee3c1f6.gif)
