### PR TITLE
Fixed consoles' height

### DIFF
--- a/src/themes/website/styles/docs.scss
+++ b/src/themes/website/styles/docs.scss
@@ -213,13 +213,15 @@ validation-summary {
     display: block;
 }
 
-operation-console {
-    background: #fafafa;
-    min-height: 100%;
+.consoles {
+    background: $panel-bg-color-highlight;
+    height: 100%;
     border-left: 1px solid #dee2e6;
 
-    .form-control {
-        margin: 0;
+    &.operation-console {
+        .form-control {
+            margin: 0;
+        }
     }
 }
 


### PR DESCRIPTION
When collapsing all regions from the console, it changes its height:
![image](https://user-images.githubusercontent.com/92857141/175921974-d1593a48-32cf-4e96-b634-bf7dc99cbde7.png)

An example of how it looks after the fix:
![image](https://user-images.githubusercontent.com/92857141/175922088-09c08d1b-daa7-4d87-8bc7-45e6d746ee3a.png)

Same behavior for the graphql-console.


