### PR TITLE
Fixed "copy" button reveals secrets in test console

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/authorization.ts
+++ b/src/components/operations/operation-details/ko/runtime/authorization.ts
@@ -10,7 +10,6 @@ import { ConsoleHeader } from "../../../../../models/console/consoleHeader";
 import { KnownHttpHeaders } from "../../../../../models/knownHttpHeaders";
 import { ConsoleOperation } from "../../../../../models/console/consoleOperation";
 import { templates } from "./templates/templates";
-import { TemplatingService } from "../../../../../services/templatingService";
 import { GrantTypes, TypeOfApi, oauthSessionKey } from "./../../../../../constants";
 import { OAuthService } from "../../../../../services/oauthService";
 import { Product } from "../../../../../models/product";
@@ -53,8 +52,6 @@ export class Authorization {
         this.queryParameters = ko.observableArray<ConsoleParameter>();
         this.consoleOperation = ko.observable<ConsoleOperation>();
         this.templates = templates;
-        this.codeSample = ko.observable<string>();
-        this.selectedLanguage = ko.observable<string>();
         this.authenticated = ko.observable(false);
         this.subscriptionKeyRequired = ko.observable();
         this.username = ko.observable();
@@ -80,10 +77,7 @@ export class Authorization {
     public queryParameters: ko.ObservableArray<ConsoleParameter>;
 
     @Param()
-    public codeSample: ko.Observable<string>;
-
-    @Param()
-    public selectedLanguage: ko.Observable<string>;
+    public updateRequestSummary: () => Promise<void>;
 
 
     @OnMounted()
@@ -259,12 +253,6 @@ export class Authorization {
         await this.setStoredCredentials(serverName, scopeOverride, grantType, accessToken);
 
         this.setAuthorizationHeader(accessToken);
-    }
-
-    public async updateRequestSummary(): Promise<void> {
-        const template = templates[this.selectedLanguage()];
-        const codeSample = await TemplatingService.render(template, ko.toJS(this.consoleOperation));
-        this.codeSample(codeSample);
     }
 
     private findHeader(name: string): ConsoleHeader {

--- a/src/components/operations/operation-details/ko/runtime/operation-console.html
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.html
@@ -82,7 +82,7 @@
         <!-- /ko -->
 
         <authorization
-            params="{ api: $component.api, authorizationServer: $component.authorizationServer, consoleOperation: $component.consoleOperation, codeSample: $component.codeSample, selectedLanguage: $component.selectedLanguage}">
+            params="{ api: $component.api, authorizationServer: $component.authorizationServer, consoleOperation: $component.consoleOperation, updateRequestSummary: $component.updateRequestSummary}">
         </authorization>
 
         <h3>Parameters

--- a/src/components/operations/operation-details/ko/runtime/templates/csharp.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/csharp.liquid
@@ -20,9 +20,9 @@ namespace CSHttpClientSample
         {
             var client = new HttpClient();
 
-{% if request.meaningfulHeaders.size > 0 %}
+{% if console.request.meaningfulHeaders.size > 0 %}
             // Request headers
-{% for header in request.meaningfulHeaders -%}
+{% for header in console.request.meaningfulHeaders -%}
 {% case header.name | downcase -%}
 {%when"content-disposition"-%}
             {%- continue %};
@@ -45,98 +45,103 @@ namespace CSHttpClientSample
 {%when  "last-modified" -%}
             {%- continue %};
 {% when "accept"%}
-            client.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("{{header.value}}"));
 {% when "accept-charset" %}
-            client.DefaultRequestHeaders.AcceptCharset.Add(StringWithQualityHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.AcceptCharset.Add(StringWithQualityHeaderValue.Parse("{{header.value}}"));
 {% when "accept-encoding" %}
-            client.DefaultRequestHeaders.AcceptEncoding.Add(StringWithQualityHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.AcceptEncoding.Add(StringWithQualityHeaderValue.Parse("{{header.value}}"));
 {% when "accept-language" %}
-            client.DefaultRequestHeaders.AcceptLanguage.Add(StringWithQualityHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.AcceptLanguage.Add(StringWithQualityHeaderValue.Parse("{{header.value}}"));
 {% when "cache-control" %}
-            client.DefaultRequestHeaders.CacheControl = CacheControlHeaderValue.Parse("{{header.displayedValue}}");
+            client.DefaultRequestHeaders.CacheControl = CacheControlHeaderValue.Parse("{{header.value}}");
 {% when "connection" %}
-            client.DefaultRequestHeaders.Connection.Add("{{header.displayedValue}}");
+            client.DefaultRequestHeaders.Connection.Add("{{header.value}}");
 {% when "date" %}
-            client.DefaultRequestHeaders.Date = DateTimeOffset.Parse("{{header.displayedValue}}");
+            client.DefaultRequestHeaders.Date = DateTimeOffset.Parse("{{header.value}}");
 {% when "expect" %}
-            client.DefaultRequestHeaders.Expect.Add(NameValueWithParametersHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.Expect.Add(NameValueWithParametersHeaderValue.Parse("{{header.value}}"));
 {% when "if-match" %}
-            client.DefaultRequestHeaders.IfMatch.Add(EntityTagHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.IfMatch.Add(EntityTagHeaderValue.Parse("{{header.value}}"));
 {% when "if-modified-since" %}
-            client.DefaultRequestHeaders.IfModifiedSince = DateTimeOffset.Parse("{{header.displayedValue}}");
+            client.DefaultRequestHeaders.IfModifiedSince = DateTimeOffset.Parse("{{header.value}}");
 {% when "if-none-match" %}
-            client.DefaultRequestHeaders.IfNoneMatch.Add(EntityTagHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.IfNoneMatch.Add(EntityTagHeaderValue.Parse("{{header.value}}"));
 {% when "if-range" %}
-            client.DefaultRequestHeaders.IfRange = RangeConditionHeaderValue.Parse("{{header.displayedValue}}");
+            client.DefaultRequestHeaders.IfRange = RangeConditionHeaderValue.Parse("{{header.value}}");
 {% when "if-unmodified-since" %}
-            client.DefaultRequestHeaders.IfUnmodifiedSince = DateTimeOffset.Parse("{{header.displayedValue}}");
+            client.DefaultRequestHeaders.IfUnmodifiedSince = DateTimeOffset.Parse("{{header.value}}");
 {% when "max-forwards" %}
-            client.DefaultRequestHeaders.MaxForwards = int.Parse("{{header.displayedValue}}");
+            client.DefaultRequestHeaders.MaxForwards = int.Parse("{{header.value}}");
 {% when "pragma" %}
-            client.DefaultRequestHeaders.Pragma.Add(NameValueHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.Pragma.Add(NameValueHeaderValue.Parse("{{header.value}}"));
 {% when "range" %}
-            client.DefaultRequestHeaders.Range = RangeHeaderValue.Parse("{{header.displayedValue}}");
+            client.DefaultRequestHeaders.Range = RangeHeaderValue.Parse("{{header.value}}");
 {% when "referer" %}
-            client.DefaultRequestHeaders.Referrer = new Uri("{{header.displayedValue}}");
+            client.DefaultRequestHeaders.Referrer = new Uri("{{header.value}}");
 {% when "te" %}
-            client.DefaultRequestHeaders.TE.Add(TransferCodingWithQualityHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.TE.Add(TransferCodingWithQualityHeaderValue.Parse("{{header.value}}"));
 {% when "transfer-encoding" %}
-            client.DefaultRequestHeaders.TransferEncoding.Add(TransferCodingHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.TransferEncoding.Add(TransferCodingHeaderValue.Parse("{{header.value}}"));
 {% when "upgrade" %}
-            client.DefaultRequestHeaders.Upgrade.Add(ProductHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.Upgrade.Add(ProductHeaderValue.Parse("{{header.value}}"));
 {% when "user-agent" %}
-            client.DefaultRequestHeaders.UserAgent.Add(ProductInfoHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.UserAgent.Add(ProductInfoHeaderValue.Parse("{{header.value}}"));
 {% when "via" %}
-            client.DefaultRequestHeaders.Via.Add(ViaHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.Via.Add(ViaHeaderValue.Parse("{{header.value}}"));
 {% when "warning" %}
-            client.DefaultRequestHeaders.Warning.Add(WarningHeaderValue.Parse("{{header.displayedValue}}"));
+            client.DefaultRequestHeaders.Warning.Add(WarningHeaderValue.Parse("{{header.value}}"));
 {% else %}
-            client.DefaultRequestHeaders.Add("{{header.name}}", "{{header.displayedValue}}");
+    {% if showSecrets == false and header.secret -%}
+        client.DefaultRequestHeaders.Add("{{header.name}}", "{{header.hiddenValue}}");
+    {% else -%}
+        client.DefaultRequestHeaders.Add("{{header.name}}", "{{header.value}}");
+    {% endif -%}
+            
 {% endcase -%}
 {% endfor -%}
 {% endif -%}
 
-            var uri = "{{requestUrl}}";
+            var uri = "{{console.requestUrl}}";
 
-{% case method -%}
+{% case console.method -%}
 
 {% when "POST" %}
             HttpResponseMessage response;
-            {%- if request.body != blank %}
+            {%- if console.request.body != blank %}
             // Request body
-{%- if request.bodyFormat == "raw"  -%}
-            {%- assign formattedBody = request.body | replace:'"','\\"' -%}
+{%- if console.request.bodyFormat == "raw"  -%}
+            {%- assign formattedBody = console.requestbody | replace:'"','\\"' -%}
             {%- assign formattedBody = formattedBody | replace: '\r\n', ' ' -%}
             {%- assign formattedBody = formattedBody | replace: '     ', ' ' %}
 
             using (var content = new StringContent("{{formattedBody}}"))
             {
-{%- elsif request.bodyFormat == "binary" %}
-            using (var content = new StreamContent(File.OpenRead(" < path\\to\\{{request.binary.name}} > ")))
+{%- elsif console.request.bodyFormat == "binary" %}
+            using (var content = new StreamContent(File.OpenRead(" < path\\to\\{{console.request.binary.name}} > ")))
             {
 {%- endif %}
-    {%- for header in request.meaningfulHeaders -%}
+    {%- for header in console.request.meaningfulHeaders -%}
         {% case header.name | downcase -%}
             {%when"content-disposition" %}
-                content.Headers.ContentDisposition = new ContentDispositionHeaderValue("{{header.displayedValue}}");
+                content.Headers.ContentDisposition = new ContentDispositionHeaderValue("{{header.value}}");
             {%when  "content-encoding" %}
-                content.Headers.ContentEncoding.Add("{{header.displayedValue}}");
+                content.Headers.ContentEncoding.Add("{{header.value}}");
             {%when  "content-language" %}
-                content.Headers.ContentLanguage.Add("{{header.displayedValue}}");
+                content.Headers.ContentLanguage.Add("{{header.value}}");
             {%when  "content-length" %}
-                content.Headers.ContentLength = {{header.displayedValue}};
+                content.Headers.ContentLength = {{header.value}};
             {%when  "content-location" %}
-                content.Headers.ContentLocation = new Uri("{{header.displayedValue}}"); 
+                content.Headers.ContentLocation = new Uri("{{header.value}}"); 
             {%when  "content-md5" %}
-                content.Headers.Add("content-md5", "{{header.displayedValue}}");
+                content.Headers.Add("content-md5", "{{header.value}}");
             {%when  "content-range" %}
-                content.Headers.ContentRange = new ContentRangeHeaderValue({{header.displayedValue}});
+                content.Headers.ContentRange = new ContentRangeHeaderValue({{header.value}});
             {%when  "content-type" %}
-                content.Headers.ContentType = new MediaTypeHeaderValue("{{header.displayedValue}}");
+                content.Headers.ContentType = new MediaTypeHeaderValue("{{header.value}}");
             {%when  "expires" %}
-                content.Headers.Add("expires", "{{header.displayedValue}}");
+                content.Headers.Add("expires", "{{header.value}}");
             {%when  "last-modified" %}
-                content.Headers.Add("last-modified", "{{header.displayedValue}}");
+                content.Headers.Add("last-modified", "{{header.value}}");
             {% else -%}
                 {%- continue -%};
         {% endcase -%}
@@ -151,40 +156,40 @@ namespace CSHttpClientSample
             var response = await client.DeleteAsync(uri);
 {% when "PUT" %}
             HttpResponseMessage response;
-{% if request.body != blank %}
+{% if console.request.body != blank %}
             // Request body
-{%- if request.bodyFormat == "raw"  -%}
-            {%- assign formattedBody = request.body | replace:'"','\\"' -%}
+{%- if console.request.bodyFormat == "raw"  -%}
+            {%- assign formattedBody = console.request.body | replace:'"','\\"' -%}
             {%- assign formattedBody = formattedBody | replace: '\r\n', ' ' -%}
             {%- assign formattedBody = formattedBody | replace: '     ', ' ' %}
             using (var content = new StringContent("{{formattedBody}}"))
             {
-{%- elsif request.bodyFormat == "binary" %}
-            using (var content = new  StreamContent(File.OpenRead(" < path\\to\\{{request.binary.name}} > ")))
+{%- elsif console.request.bodyFormat == "binary" %}
+            using (var content = new  StreamContent(File.OpenRead(" < path\\to\\{{console.request.binary.name}} > ")))
             {
 {%- endif %}
-{%- for header in request.meaningfulHeaders -%}
+{%- for header in console.request.meaningfulHeaders -%}
     {% case header.name | downcase -%}
         {%when"content-disposition" %}
-            content.Headers.ContentDisposition = new ContentDispositionHeaderValue("{{header.displayedValue}}");
+            content.Headers.ContentDisposition = new ContentDispositionHeaderValue("{{header.value}}");
         {%when  "content-encoding" %}
-            content.Headers.ContentEncoding.Add("{{header.displayedValue}}");
+            content.Headers.ContentEncoding.Add("{{header.value}}");
         {%when  "content-language" %}
-            content.Headers.ContentLanguage.Add("{{header.displayedValue}}");
+            content.Headers.ContentLanguage.Add("{{header.value}}");
         {%when  "content-length" %}
-            content.Headers.ContentLength = {{header.displayedValue}};
+            content.Headers.ContentLength = {{header.value}};
         {%when  "content-location" %}
-            content.Headers.ContentLocation = new Uri("{{header.displayedValue}}"); 
+            content.Headers.ContentLocation = new Uri("{{header.value}}"); 
         {%when  "content-md5" %}
-            content.Headers.Add("content-md5", "{{header.displayedValue}}");
+            content.Headers.Add("content-md5", "{{header.value}}");
         {%when  "content-range" %}
-            content.Headers.ContentRange = new ContentRangeHeaderValue({{header.displayedValue}});
+            content.Headers.ContentRange = new ContentRangeHeaderValue({{header.value}});
         {%when  "content-type" %}
-            content.Headers.ContentType = new MediaTypeHeaderValue("{{header.displayedValue}}");
+            content.Headers.ContentType = new MediaTypeHeaderValue("{{header.value}}");
         {%when  "expires" %}
-            content.Headers.Add("expires", "{{header.displayedValue}}");
+            content.Headers.Add("expires", "{{header.value}}");
         {%when  "last-modified" %}
-            content.Headers.Add("last-modified", "{{header.displayedValue}}");
+            content.Headers.Add("last-modified", "{{header.value}}");
         {% else -%}
             {%- continue -%};
     {% endcase -%}

--- a/src/components/operations/operation-details/ko/runtime/templates/curl.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/curl.liquid
@@ -1,11 +1,16 @@
-curl -v -X {{method}} "{{requestUrl}}"
-{%- for header in request.meaningfulHeaders %} -H "{{ header.name }}: {{ header.displayedValue }}"
+curl -v -X {{console.method}} "{{console.requestUrl}}"
+{%- for header in console.request.meaningfulHeaders %} -H "
+{%- if showSecrets == false and header.secret -%}
+{{ header.name }}: {{ header.hiddenValue }}
+{%- else -%}
+{{ header.name }}: {{ header.value }}
+{%- endif -%}"
 {%- endfor -%}
-{% if request.body != blank -%}
-{%- if request.bodyFormat == "raw" -%}
-{%- assign formattedBody = request.body | replace:'"','\\"' -%}
+{% if console.request.body != blank -%}
+{%- if console.request.bodyFormat == "raw" -%}
+{%- assign formattedBody = console.request.body | replace:'"','\\"' -%}
 {%- assign formattedBody = formattedBody | replace: '\r\n', ' ' -%}
 {%- assign formattedBody = formattedBody | replace: '     ', ' ' %} --data-raw "{{formattedBody}}"
-{%- elsif request.bodyFormat == "binary" %} --data-binary "@ < path/to/{{request.binary.name}} >"
+{%- elsif console.request.bodyFormat == "binary" %} --data-binary "@ < path/to/{{console.request.binary.name}} >"
 {% endif -%}
 {% endif -%}

--- a/src/components/operations/operation-details/ko/runtime/templates/http.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/http.liquid
@@ -1,11 +1,15 @@
-{{method}} {{requestUrl}} HTTP/1.1
+{{console.method}} {{console.requestUrl}} HTTP/1.1
 
-{% for header in request.meaningfulHeaders -%}
-{{ header.name }}: {{ header.displayedValue }}
-{% endfor %}
-{% if request.body != blank and request.bodyFormat == "raw" -%}
-{{ request.body }}
+{% for header in console.request.meaningfulHeaders -%}
+{% if showSecrets == false and header.secret -%}
+{{ header.name }}: {{ header.hiddenValue }}
+{% else -%}
+{{ header.name }}: {{ header.value }}
 {% endif -%}
-{% if request.binary != blank and request.bodyFormat == "binary" -%}
-[ {{ request.binary.name }} ]
+{% endfor %}
+{% if console.request.body != blank and console.request.bodyFormat == "raw" -%}
+{{ console.request.body }}
+{% endif -%}
+{% if console.request.binary != blank and console.request.bodyFormat == "binary" -%}
+[ {{ console.request.binary.name }} ]
 {% endif -%}

--- a/src/components/operations/operation-details/ko/runtime/templates/java.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/java.liquid
@@ -14,21 +14,26 @@ public class HelloWorld {
 
   public static void main(String[] args) {
     try {
-        String urlString = "{{requestUrl}}";
+        String urlString = "{{console.requestUrl}}";
         URL url = new URL(urlString);
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
 
         //Request headers
-{%- for header in request.meaningfulHeaders %}
-        connection.setRequestProperty("{{header.name}}", "{{header.displayedValue}}");
+{%- for header in console.request.meaningfulHeaders %}
+    {% if showSecrets == false and header.secret -%}
+        connection.setRequestProperty("{{header.name}}", "{{header.hiddenValue}}");
+    {% else -%}
+        connection.setRequestProperty("{{header.name}}", "{{header.value}}");
+    {% endif -%}
+        
 {% endfor %}
-        connection.setRequestMethod("{{method}}");
-{% if method == "POST" or method == "PUT" -%}
-    {%- if request.body != blank %}
+        connection.setRequestMethod("{{console.method}}");
+{% if console.method == "POST" or console.method == "PUT" -%}
+    {%- if console.request.body != blank %}
         // Request body
         connection.setDoOutput(true);
-    {%- if request.bodyFormat == "raw"  -%}
-    {%- assign formattedBody = request.body | replace:'"','\\"' -%}
+    {%- if console.request.bodyFormat == "raw"  -%}
+    {%- assign formattedBody = console.request.body | replace:'"','\\"' -%}
     {%- assign formattedBody = formattedBody | replace: '\r\n', ' ' -%}
     {%- assign formattedBody = formattedBody | replace: '\n', ' ' -%}
     {%- assign formattedBody = formattedBody | replace: '     ', ' ' %}
@@ -37,8 +42,8 @@ public class HelloWorld {
             .write(
              "{{formattedBody}}".getBytes()
              );
-    {%- elsif request.bodyFormat == "binary" %}
-        String fileName = "< path/to/{{request.binary.name}} >";
+    {%- elsif console.request.bodyFormat == "binary" %}
+        String fileName = "< path/to/{{console.request.binary.name}} >";
         InputStream is = new FileInputStream(fileName);
         byte[] bytes = new byte[(int) is.available()];
         DataInputStream dataInputStream = new DataInputStream(is);

--- a/src/components/operations/operation-details/ko/runtime/templates/javascript.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/javascript.liquid
@@ -1,19 +1,23 @@
 
-{%- if request.body != blank and request.bodyFormat == "raw" -%}
+{%- if console.request.body != blank and console.request.bodyFormat == "raw" -%}
 // Request body
-const body = {{request.body}};
+const body = {{console.request.body}};
 {%- endif %}
 
-fetch('{{requestUrl}}', {
-        method: '{{method | upcase}}',
-        {%- if request.body != blank %}
+fetch('{{console.requestUrl}}', {
+        method: '{{console.method | upcase}}',
+        {%- if console.request.body != blank %}
         body: JSON.stringify(body),
         {%- endif -%}
-        {% if request.meaningfulHeaders.size > 0 %}
+        {% if console.request.meaningfulHeaders.size > 0 %}
         // Request headers
         headers: {
-        {%- for header in request.meaningfulHeaders %}
-            '{{header.name}}': '{{header.displayedValue}}',
+        {%- for header in console.request.meaningfulHeaders %}
+            {% if showSecrets == false and header.secret -%}
+                '{{header.name}}': '{{header.hiddenValue}}',
+            {%- else -%}
+                '{{header.name}}': '{{header.value}}',
+            {%- endif -%}
         {%- endfor -%}
         {%- endif -%}
         }

--- a/src/components/operations/operation-details/ko/runtime/templates/php.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/php.liquid
@@ -1,27 +1,31 @@
 <?php
 
-$url = "{{requestUrl}}";
+$url = "{{console.requestUrl}}";
 $curl = curl_init($url);
 
-curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "{{method}}");
+curl_setopt($curl, CURLOPT_CUSTOMREQUEST, "{{console.method}}");
 curl_setopt($curl, CURLOPT_URL, $url);
 curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 
-{% if request.meaningfulHeaders.size > 0 -%}
+{% if console.request.meaningfulHeaders.size > 0 -%}
 # Request headers
 $headers = array(
-{%- for header in request.meaningfulHeaders %}
-    '{{header.name}}: {{header.displayedValue}}',
+{%- for header in console.request.meaningfulHeaders %}
+    {% if showSecrets == false and header.secret -%}
+        '{{header.name}}: {{header.hiddenValue}}',
+    {%- else -%}
+       '{{header.name}}: {{header.value}}',
+    {%- endif -%}
 {%- endfor -%});
 curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
 {%- endif %}
-{% if request.body != blank %}
+{% if console.request.body != blank %}
 # Request body
-{% if request.bodyFormat == "raw" -%}
-$request_body = '{{request.body}}';
-{%- elsif  request.bodyFormat == "binary" %}
-$file = fopen("< path\\to\\{{request.binary.name}} >", "r");
-$request_body = fread($file,filesize("< path\\to\\{{request.binary.name}} >"));
+{% if console.request.bodyFormat == "raw" -%}
+$request_body = '{{console.request.body}}';
+{%- elsif  console.request.bodyFormat == "binary" %}
+$file = fopen("< path\\to\\{{console.request.binary.name}} >", "r");
+$request_body = fread($file,filesize("< path\\to\\{{console.request.binary.name}} >"));
 fclose($file);
 {% endif %}
 curl_setopt($curl, CURLOPT_POSTFIELDS, $request_body);

--- a/src/components/operations/operation-details/ko/runtime/templates/python.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/python.liquid
@@ -2,21 +2,25 @@
 import urllib.request, json
 
 try:
-    url = "{{requestUrl}}"
+    url = "{{console.requestUrl}}"
 
     hdr ={
     # Request headers
-{%- for header in request.meaningfulHeaders %}
-    '{{header.name}}': '{{header.displayedValue}}',
+{%- for header in console.request.meaningfulHeaders %}
+    {% if showSecrets == false and header.secret -%}
+        '{{header.name}}': '{{header.hiddenValue}}',
+    {%- else -%}
+        '{{header.name}}': '{{header.value}}',
+    {%- endif -%}
 {%- endfor %}
     }
-{% if request.body != blank %}
+{% if console.request.body != blank %}
     # Request body
-{%- if request.bodyFormat == "raw" %}
+{%- if console.request.bodyFormat == "raw" %}
     data =  {{request.body}}
     data = json.dumps(data)
     req = urllib.request.Request(url, headers=hdr, data = bytes(data.encode("utf-8")))
-{%- elsif  request.bodyFormat == "binary" %}
+{%- elsif  console.request.bodyFormat == "binary" %}
     with open('< path/to/{{request.binary.name}} >', 'rb') as f:
         data = f.read()
     req = urllib.request.Request(url, headers=hdr, data = bytes(data))
@@ -24,7 +28,7 @@ try:
 {% else %}
     req = urllib.request.Request(url, headers=hdr)
 {% endif %}
-    req.get_method = lambda: '{{method}}'
+    req.get_method = lambda: '{{console.method}}'
     response = urllib.request.urlopen(req)
     print(response.getcode())
     print(response.read())

--- a/src/components/operations/operation-details/ko/runtime/templates/ruby.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/ruby.liquid
@@ -1,20 +1,24 @@
 require 'net/http'
 
-uri = URI('{{requestUrl}}')
+uri = URI('{{console.requestUrl}}')
 
 
-request = Net::HTTP::{{ method | downcase | capitalize }}.new(uri.request_uri)
+request = Net::HTTP::{{ console.method | downcase | capitalize }}.new(uri.request_uri)
 
 # Request headers
-{% for header in request.meaningfulHeaders -%}
-request['{{header.name}}'] = '{{header.displayedValue}}'
+{% for header in console.request.meaningfulHeaders -%}
+{% if showSecrets == false and header.secret -%}
+    request['{{header.name}}'] = '{{header.hiddenValue}}'
+{% else -%}
+    request['{{header.name}}'] = '{{header.value}}'
+{% endif -%}
 {% endfor %}
-{% if request.body != blank -%}
+{% if console.request.body != blank -%}
 # Request body
-{% if request.bodyFormat == "raw" -%}
-request.body = '{{ request.body }}'
-{%- elsif  request.bodyFormat == "binary" -%}
-request.body = File.read("< path/to/{{request.binary.name}} >")
+{% if console.request.bodyFormat == "raw" -%}
+request.body = '{{ console.request.body }}'
+{%- elsif  console.request.bodyFormat == "binary" -%}
+request.body = File.read("< path/to/{{console.request.binary.name}} >")
 {% endif %}
 {% endif %}
 response = Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|

--- a/src/components/operations/operation-details/ko/runtime/templates/swift.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/swift.liquid
@@ -1,26 +1,30 @@
 import Foundation
 import FoundationNetworking
 
-let url = URL(string: "{{requestUrl}}") 
+let url = URL(string: "{{console.requestUrl}}") 
 var request : URLRequest = URLRequest(url: url!)
-request.httpMethod = "{{method}}"
+request.httpMethod = "{{console.method}}"
 
 // Request headers 
 let headers = [
-{% for header in request.meaningfulHeaders %}
-"{{header.name}}": "{{header.displayedValue}}",
+{% for header in console.request.meaningfulHeaders %}
+    {% if showSecrets == false and header.secret -%}
+        "{{header.name}}": "{{header.hiddenValue}}",
+    {%- else -%}
+        "{{header.name}}": "{{header.value}}",
+    {%- endif -%}
 {%- endfor %}
 ]
 request.allHTTPHeaderFields = headers
-{% if request.body != blank %}
+{% if console.request.body != blank %}
 // Request body
-{%- if request.bodyFormat == "raw" -%}
-{%- assign formattedBody = request.body | replace:'"','\\"' -%}
+{%- if console.request.bodyFormat == "raw" -%}
+{%- assign formattedBody = console.request.body | replace:'"','\\"' -%}
 {%- assign formattedBody = formattedBody | replace: '\r\n', ' ' -%}
 {%- assign formattedBody = formattedBody | replace: '     ', ' ' %}
 let postString = "{{formattedBody}}"
 request.httpBody = postString.data(using: .utf8)
-{%- elsif  request.bodyFormat == "binary" %}
+{%- elsif  console.request.bodyFormat == "binary" %}
 let file = "< path/to/{{request.binary.name}} >" 
 var result = ""
 if let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {       

--- a/src/components/operations/operation-details/ko/runtime/templates/ws_csharp.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/ws_csharp.liquid
@@ -16,7 +16,12 @@ namespace CSWebSocketClientSample
         static async Task StartWebSocketClient()
         {
             ClientWebSocket client = new ClientWebSocket();
-            Uri uri = new Uri("{{displayedWsUrl}}");
+            Uri uri = new Uri("
+            {%- if showSecrets == false -%}
+                {{console.hiddenWsUrl}}
+            {%- else -%}
+                {{console.wsUrl}}
+            {%- endif -%}");
             var cts = new CancellationTokenSource();
             await client.ConnectAsync(uri, CancellationToken.None);
 

--- a/src/components/operations/operation-details/ko/runtime/templates/ws_javascript.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/ws_javascript.liquid
@@ -1,4 +1,9 @@
-let socket = new WebSocket("{{displayedWsUrl}}");
+let socket = new WebSocket("
+{%- if showSecrets == false -%}
+    {{console.hiddenWsUrl}}
+{%- else -%}
+    {{console.wsUrl}}
+{%- endif -%}");
 
 socket.onopen = function(e) {
   alert("[open] Connection established");

--- a/src/components/operations/operation-details/ko/runtime/templates/ws_wscat.liquid
+++ b/src/components/operations/operation-details/ko/runtime/templates/ws_wscat.liquid
@@ -1,1 +1,5 @@
-wscat -c {{displayedWsUrl}}
+{%- if showSecrets == false -%}
+wscat -c {{console.hiddenWsUrl}}
+{% else -%}
+wscat -c {{console.wsUrl}}
+{%- endif -%}

--- a/src/models/console/consoleHeader.ts
+++ b/src/models/console/consoleHeader.ts
@@ -13,7 +13,7 @@ export class ConsoleHeader {
     public revealed: ko.Observable<boolean>;
     public description: string;
     public type: string;
-    public displayedValue: ko.Observable<string>;
+    public hiddenValue: ko.Computed<string>;
 
     public toggleRevealed(): void {
         this.revealed(!this.revealed());
@@ -28,7 +28,6 @@ export class ConsoleHeader {
         this.name = ko.observable();
         this.value = ko.observable();
         this.revealed = ko.observable(false);
-        this.displayedValue = ko.observable();
         this.inputTypeValue = ko.observable("text");
         this.options = [];
         this.required = false;
@@ -36,12 +35,9 @@ export class ConsoleHeader {
         this.custom = true;
         this.type = "string";
         this.description = "Additional header.";
+        this.hiddenValue = ko.computed<string>(() => this.value()?.replace(/./g, "•"));
 
-        this.value.subscribe(() => {
-            this.displayedValue((this.secret && !this.revealed()) ? this.value()?.replace(/./g, "•") : this.value());
-        });
         this.revealed.subscribe(() => {
-            this.displayedValue((this.secret && !this.revealed()) ? this.value().replace(/./g, "•") : this.value());
             this.inputTypeValue(this.secret && !this.revealed() ? "password" : "text");
         });
 

--- a/src/models/console/consoleOperation.ts
+++ b/src/models/console/consoleOperation.ts
@@ -22,7 +22,7 @@ export class ConsoleOperation {
     public readonly hasBody: ko.Observable<boolean>;
     public readonly request: ConsoleRequest;
     public urlTemplate: string;
-    public readonly displayedWsUrl: ko.Computed<string>;
+    public readonly hiddenWsUrl: ko.Computed<string>;
     public readonly canHaveBody: boolean;
 
     constructor(api: Api, operation: Operation) {
@@ -67,7 +67,7 @@ export class ConsoleOperation {
             return result;
         });
 
-        this.displayedWsUrl = ko.computed(() => {
+        this.hiddenWsUrl = ko.computed(() => {
             const protocol = this.api.protocols.indexOf("wss") !== -1 ? "wss" : "wss";
             const urlTemplate = this.getRequestPath(true);
             const result = `${protocol}://${this.host.hostname()}${Utils.ensureLeadingSlash(urlTemplate)}`;
@@ -119,12 +119,12 @@ export class ConsoleOperation {
                 if (requestUrl.indexOf(parameterPlaceholder) > -1) {
                     requestUrl = requestUrl.replace(parameterPlaceholder,
                         !getHidden || !parameter.secret ? Utils.encodeURICustomized(parameter.value())
-                            : (parameter.revealed() ? Utils.encodeURICustomized(parameter.value()) : parameter.value().replace(/./g, "•")));
+                            : parameter.value().replace(/./g, "•"));
                 }
                 else {
                     requestUrl = this.addParam(requestUrl, Utils.encodeURICustomized(parameter.name()),
                         !getHidden || !parameter.secret ? Utils.encodeURICustomized(parameter.value())
-                            : (parameter.revealed() ? Utils.encodeURICustomized(parameter.value()) : parameter.value().replace(/./g, "•")));
+                            : parameter.value().replace(/./g, "•"));
                 }
             }
         });


### PR DESCRIPTION
## Problem
When clicking "copy", the secret headers values from the headers section are revealed:
![copy-reveal](https://user-images.githubusercontent.com/92857141/180056738-d1fc7d39-183b-494c-9b3d-6a1598b682df.gif)

Also, when clicking "show" for the code sample, the headers are revealed:
![show-reveal](https://user-images.githubusercontent.com/92857141/180056792-a7f7f8ef-8e08-46fc-943f-f4a4e1670570.gif)

## Solution
I kept the same logic for displaying/hiding the secret values for the header list and I changed the one for displaying the code samples (so they can work independently):
Now, there is a new parameter that is sent to the render method, based on which the decision if the values are hidden or displayed is made, inside the liquid templates.
