### PR TITLE
Remove locales from search

### DIFF
--- a/src/persistence/mapiObjectStorage.ts
+++ b/src/persistence/mapiObjectStorage.ts
@@ -394,24 +394,10 @@ export class MapiObjectStorage implements IObjectStorage {
         const isLocalized = localizedContentTypes.includes(contentType);
         const localeSearchPrefix = isLocalized ? `${selectedLocale}/` : "";
 
-        if (key === "popups") {
-            const pageOfPopups: Page<PopupInstanceModel> = {
+        if (key === "popups" || key === "locales") {
+            return  {
                 value: []
             };
-
-            return <any>pageOfPopups;
-        }
-
-        if (key === "locales") {
-            const pageOfLocales: Page<LocaleModel> = {
-                value: [{
-                    key: `contentTypes/locales/contentItem/en_us`,
-                    code: "en-us",
-                    displayName: "English (US)"
-                }]
-            };
-
-            return <any>pageOfLocales;
         }
 
         try {


### PR DESCRIPTION
Publishment is publishing files two times. Paperbits is adding en locale but itself and then ask storage for more locales. if we return locale then two renders are triggered for the same locale. This PR should remove it.