### PR TITLE
Fixed authorization header remove logic

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/authorization.ts
+++ b/src/components/operations/operation-details/ko/runtime/authorization.ts
@@ -142,6 +142,7 @@ export class Authorization {
 
         if (authorizationHeader) {
             authorizationHeader.value(accessToken);
+            this.deleteAuthorizationHeader = false;
             return;
         }
 
@@ -149,7 +150,7 @@ export class Authorization {
         const keyHeader = new ConsoleHeader();
         keyHeader.name(KnownHttpHeaders.Authorization);
         keyHeader.description = "Subscription key.";
-        keyHeader.secret = true;
+        keyHeader.secret(true);
         keyHeader.inputTypeValue("password");
         keyHeader.type = "string";
         keyHeader.required = false;
@@ -197,7 +198,7 @@ export class Authorization {
         const keyHeader = new ConsoleHeader();
         keyHeader.name(subscriptionKeyHeaderName);
         keyHeader.description = "Subscription key.";
-        keyHeader.secret = true;
+        keyHeader.secret(true);
         keyHeader.inputTypeValue("password");
         keyHeader.type = "string";
         keyHeader.required = true;

--- a/src/components/operations/operation-details/ko/runtime/operation-console.html
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.html
@@ -219,12 +219,12 @@
                             <!-- /ko -->
                             <!-- ko if: !header.options || header.options.length === 0 -->
                             <div class="input-group has-validation">
-                                <!-- ko if: !header.secret -->
+                                <!-- ko if: !header.secret() -->
                                 <input type="text" autocomplete="off" class="form-control form-control-sm"
                                     placeholder="value" spellcheck="false" aria-label="Header value"
                                     data-bind="textInput: header.value, attr:{'aria-required': header.required}">
                                 <!-- /ko -->
-                                <!-- ko if: header.secret -->
+                                <!-- ko if: header.secret() -->
                                 <input autocomplete="off" class="form-control form-control-sm" placeholder="value"
                                     spellcheck="false" aria-label="Header value"
                                     data-bind="attr: {type: header.inputTypeValue, 'aria-required': header.required}, textInput: header.value">

--- a/src/components/operations/operation-details/ko/runtime/operation-console.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.ts
@@ -239,6 +239,7 @@ export class OperationConsole {
         }
 
         this.consoleOperation().request.headers().forEach(header => header.value.subscribe(_ => this.updateRequestSummary()));
+        this.consoleOperation().request.headers().forEach(header => header.name.subscribe(_ => this.updateRequestSummary()));
         this.consoleOperation().request.body.subscribe(_ => this.updateRequestSummary());
         this.consoleOperation().request.queryParameters().forEach(parameter => parameter.value.subscribe(_ => this.updateRequestSummary()));
 
@@ -320,6 +321,7 @@ export class OperationConsole {
         const newHeader = new ConsoleHeader();
         this.consoleOperation().request.headers.push(newHeader);
         newHeader.value.subscribe(_ => this.updateRequestSummary());
+        newHeader.name.subscribe(_ => this.updateRequestSummary());
 
         this.updateRequestSummary();
     }

--- a/src/components/operations/operation-details/ko/runtime/operation-console.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.ts
@@ -238,7 +238,7 @@ export class OperationConsole {
             this.setVersionHeader();
         }
 
-        this.consoleOperation().request.meaningfulHeaders().forEach(header => header.value.subscribe(_ => this.updateRequestSummary()));
+        this.consoleOperation().request.headers().forEach(header => header.value.subscribe(_ => this.updateRequestSummary()));
         this.consoleOperation().request.body.subscribe(_ => this.updateRequestSummary());
         this.consoleOperation().request.queryParameters().forEach(parameter => parameter.value.subscribe(_ => this.updateRequestSummary()));
 

--- a/src/models/console/consoleHeader.ts
+++ b/src/models/console/consoleHeader.ts
@@ -10,7 +10,7 @@ export class ConsoleHeader {
     public readonly options: string[];
     public inputTypeValue: ko.Observable<string>;
     public required: boolean;
-    public secret: boolean;
+    public secret: ko.Observable<boolean>;
     public revealed: ko.Observable<boolean>;
     public description: string;
     public type: string;
@@ -28,6 +28,7 @@ export class ConsoleHeader {
     constructor(contract?: Parameter) {
         this.name = ko.observable(null);
         this.value = ko.observable(null);
+        this.secret = ko.observable();
         this.revealed = ko.observable(false);
         this.inputTypeValue = ko.observable("text");
         this.options = [];
@@ -38,8 +39,18 @@ export class ConsoleHeader {
         this.description = "Additional header.";
         this.hiddenValue = ko.computed<string>(() => this.value()?.replace(/./g, "•"));
 
+        this.name.subscribe(name => {
+            if (name == KnownHttpHeaders.Authorization) {
+                this.secret(true);
+            } else {
+                this.secret(false);
+            }
+        });
+
+        this.secret.subscribe(() => this.inputTypeValue((this.secret() && !this.revealed() ? "password" : "text")));
+
         this.revealed.subscribe(() => {
-            this.inputTypeValue(this.secret && !this.revealed() ? "password" : "text");
+            this.inputTypeValue(this.secret() && !this.revealed() ? "password" : "text");
         });
 
         this.name.extend(<any>{ required: { message: `Name is required.` } });
@@ -53,8 +64,7 @@ export class ConsoleHeader {
         this.options = contract.values;
         this.description = contract.description ? contract.description : "";
         this.type = contract.type;
-        this.secret = this.name() == KnownHttpHeaders.Authorization ? true : false;
-        this.inputTypeValue(this.secret && !this.revealed() ? "password" : "text");
+        this.secret(this.name() == KnownHttpHeaders.Authorization ? true : false);
 
         if (this.required) {
             this.value.extend(<any>{ required: { message: `Value is required.` } });

--- a/src/models/console/consoleHeader.ts
+++ b/src/models/console/consoleHeader.ts
@@ -1,4 +1,5 @@
 import * as ko from "knockout";
+import { KnownHttpHeaders } from "../knownHttpHeaders";
 import { Parameter } from "../parameter";
 
 export class ConsoleHeader {
@@ -52,7 +53,7 @@ export class ConsoleHeader {
         this.options = contract.values;
         this.description = contract.description ? contract.description : "";
         this.type = contract.type;
-        this.secret = false;
+        this.secret = this.name() == KnownHttpHeaders.Authorization ? true : false;
         this.inputTypeValue(this.secret && !this.revealed() ? "password" : "text");
 
         if (this.required) {


### PR DESCRIPTION
## Problem
The Authorization header is not correctly refreshed in test console. Its value is removed when selecting "No auth" and the Http Request is not updated accordingly.

## Solution
1. If the authorization header is added as a separate header for the API and marked as required, it will not be removed when selecting "No auth". 
Its value will be removed and the HTTP Request will be updated accordingly. 
Users cannot remove this header. 
It is marked as  required by the text "Value is required" under the input.
<img src="https://user-images.githubusercontent.com/92857141/189874097-75e7a258-3e18-48ae-9021-3c922747c701.gif" height="700px"/>

2. If If the authorization header is added as a separate header for the API and not marked as required, it will not be removed when selecting "No auth".  
Its value will be removed and the HTTP Request will be updated accordingly. 
Users can remove this header manually.
<img src="https://user-images.githubusercontent.com/92857141/189874109-0aca4227-04b8-46a0-a6d7-b90f9a3e3f4c.gif" height="700px"/>

3. If the authorization header is not defined for the API, when a grant type is selected (eg: "implicit"), it will be added in the Headers section, and its value will be populated. 
When "No auth" is selected, the header will be removed and the HTTP Request will be updated accordingly. 
Users can remove this header manually.
<img src="https://user-images.githubusercontent.com/92857141/189874134-048c9075-4dfb-4354-b3ed-d9de999965e7.gif" height="700px"/>

The authorization header is always marked as secret: It will always be displayed with its value masked out and with the additional toggle button that provides the possibility to display its actual value.
![auth_rename](https://user-images.githubusercontent.com/92857141/189959814-4d5cfa2e-6634-467a-94a7-eda66fc74cff.gif)

Closes #1933 