### PR TITLE
Handle multiple authorization servers

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/authorization.html
+++ b/src/components/operations/operation-details/ko/runtime/authorization.html
@@ -1,5 +1,5 @@
-<!-- ko if: $component.authorizationServer() || $component.subscriptionKeyRequired() -->
-<h3 class="pt-0">Authorization 
+<!-- ko if: $component.authorizationServers() || $component.subscriptionKeyRequired() -->
+<h3 class="pt-0">Authorization
     <button aria-label="Collapse authorization" class="no-border" data-bind="activate: $component.collapseAuth">
         <!-- ko if: $component.collapsedAuth -->
         <i class="icon-emb icon-emb-chevron-down"></i>
@@ -11,16 +11,38 @@
 </h3>
 
 <!-- ko ifnot: $component.collapsedAuth -->
-<!-- ko if: $component.authorizationServer -->
+<!-- ko if: $component.authorizationServers()?.length > 0 -->
 <div class="row flex flex-row">
     <div class="col-4">
-        <label for="authServer" class="text-monospace form-label"
-            data-bind="text: $component.authorizationServer().displayName"></label>
+        <label for="authSerer" class="text-monospace form-label">Authorization server: </label>
+    </div>
+    <!-- ko if: $component.authorizationServers().length > 1 -->
+    <div class="col-7">
+        <select id="authServer" class="form-control" data-bind="value: $component.selectedAuthorizationServer">
+            <!-- ko foreach: { data: $component.authorizationServers, as: 'authorizationServer' } -->
+            <option data-bind="value: authorizationServer, text:authorizationServer.displayName">
+            </option>
+            <!-- /ko -->
+        </select>
+    </div>
+    <!-- /ko -->
+
+    <!-- ko if: $component.authorizationServers().length == 1 -->
+    <div class="col-7">
+        <label id="authServer" class="text-monospace form-label"
+            data-bind="text: $component.selectedAuthorizationServer().displayName"></label>
+    </div>
+    <!-- /ko -->
+</div>
+
+<div class="row flex flex-row">
+    <div class="col-4">
+        <label for="authFlow" class="text-monospace form-label">Authorization flow: </label>
     </div>
     <div class="col-7">
         <div class="form-group">
-            <select id="authServer" class="form-control"
-                data-bind="options: $component.authorizationServer().grantTypes, value: $component.selectedGrantType, optionsCaption: 'No auth'">
+            <select id="authFlow" class="form-control"
+                data-bind="options: $component.selectedAuthorizationServer().grantTypes, value: $component.selectedGrantType, optionsCaption: 'No auth'">
             </select>
         </div>
     </div>

--- a/src/components/operations/operation-details/ko/runtime/graphql-console.html
+++ b/src/components/operations/operation-details/ko/runtime/graphql-console.html
@@ -30,7 +30,7 @@
 
             <div class="mw-600">
                 <authorization
-                    params="{ api: api, authorizationServer: authorizationServer, headers: headers, queryParameters: queryParameters }">
+                    params="{ api: api, authorizationServers: authorizationServers, headers: headers, queryParameters: queryParameters }">
                 </authorization>
 
                 <h3 class="pt-0">Parameters

--- a/src/components/operations/operation-details/ko/runtime/graphql-console.ts
+++ b/src/components/operations/operation-details/ko/runtime/graphql-console.ts
@@ -96,7 +96,7 @@ export class GraphqlConsole {
         this.editorErrors = ko.observableArray([]);
         this.api = ko.observable<Api>();
         this.sendingRequest = ko.observable(false);
-        this.authorizationServer = ko.observable();
+        this.authorizationServers = ko.observable();
         this.hostnames = ko.observable();
         this.host = new ConsoleHost();
         this.queryParameters = ko.observableArray();
@@ -130,7 +130,7 @@ export class GraphqlConsole {
     public hostnames: ko.Observable<string[]>;
 
     @Param()
-    public authorizationServer: ko.Observable<AuthorizationServer>;
+    public authorizationServers: ko.Observable<AuthorizationServer[]>;
 
     @Param()
     public useCorsProxy: ko.Observable<boolean>;

--- a/src/components/operations/operation-details/ko/runtime/oauth-server-configuration.html
+++ b/src/components/operations/operation-details/ko/runtime/oauth-server-configuration.html
@@ -8,22 +8,19 @@
 </div>
 <!-- /ko -->
 
-<div class="row flex flex-row">
+<div class="row flex flex-row align-items-center">
     <div class="col-2">
         <div class="form-group">
-            <div class="form-group">
-                <label for="username" class="text-monospace form-label">Description</label>
-            </div>
+            <label class="text-monospace form-label">Description</label>
         </div>
     </div>
-    <div class="col-6 align-self-center">
+    <div class="col-6">
         <div class="form-group">
             <div class="input-group">
                 <input autocomplete="off" class="form-control form-control-sm" placeholder="value" spellcheck="false"
-                    aria-label="Supported grant flows" readonly
-                    data-bind="textInput: authorizationServer.description">
-                <button class="input-group-addon no-border"
-                    data-bind="copyToClipboard: authorizationServer.description" aria-label="Copy to clipboard">
+                    aria-label="Supported grant flows" readonly data-bind="textInput: authorizationServer.description">
+                <button class="input-group-addon no-border" data-bind="copyToClipboard: authorizationServer.description"
+                    aria-label="Copy to clipboard">
                     <i class="icon-emb icon-emb-duplicate"></i>
                 </button>
             </div>
@@ -31,15 +28,13 @@
     </div>
 </div>
 
-<div class="row flex flex-row">
+<div class="row flex flex-row align-items-center">
     <div class="col-2">
         <div class="form-group">
-            <div class="form-group">
-                <label for="username" class="text-monospace form-label">Supported grant flows</label>
-            </div>
+            <label class="text-monospace form-label">Supported grant flows</label>
         </div>
     </div>
-    <div class="col-6 align-self-center">
+    <div class="col-6">
         <div class="form-group">
             <div class="input-group">
                 <input autocomplete="off" class="form-control form-control-sm" placeholder="value" spellcheck="false"
@@ -54,15 +49,13 @@
     </div>
 </div>
 
-<div class="row flex flex-row">
+<div class="row flex flex-row align-items-center">
     <div class="col-2">
         <div class="form-group">
-            <div class="form-group">
-                <label for="username" class="text-monospace form-label">Authorization endpoint</label>
-            </div>
+            <label class="text-monospace form-label">Authorization endpoint</label>
         </div>
     </div>
-    <div class="col-6 align-self-center">
+    <div class="col-6">
         <div class="form-group">
             <div class="input-group">
                 <input autocomplete="off" class="form-control form-control-sm" placeholder="value" spellcheck="false"
@@ -79,15 +72,13 @@
     </div>
 </div>
 
-<div class="row flex flex-row">
+<div class="row flex flex-row align-items-center">
     <div class="col-2">
         <div class="form-group">
-            <div class="form-group">
-                <label for="username" class="text-monospace form-label">Token endpoint</label>
-            </div>
+            <label class="text-monospace form-label">Token endpoint</label>
         </div>
     </div>
-    <div class="col-6 align-self-center">
+    <div class="col-6">
         <div class="form-group">
             <div class="input-group">
                 <input autocomplete="off" class="form-control form-control-sm" placeholder="value" spellcheck="false"
@@ -101,15 +92,13 @@
     </div>
 </div>
 
-<div class="row flex flex-row">
+<div class="row flex flex-row align-items-center">
     <div class="col-2">
         <div class="form-group">
-            <div class="form-group">
-                <label for="username" class="text-monospace form-label">Scopes</label>
-            </div>
+            <label class="text-monospace form-label">Scopes</label>
         </div>
     </div>
-    <div class="col-6 align-self-center">
+    <div class="col-6">
         <div class="form-group">
             <div class="input-group">
                 <input autocomplete="off" class="form-control form-control-sm" placeholder="value" spellcheck="false"

--- a/src/components/operations/operation-details/ko/runtime/oauth-server-configuration.html
+++ b/src/components/operations/operation-details/ko/runtime/oauth-server-configuration.html
@@ -1,3 +1,36 @@
+<!-- ko foreach: { data: authorizationServers, as: 'authorizationServer' } -->
+
+<!-- ko if: $component.displayServersName -->
+<div class="row flex flex-row">
+    <div class="col-auto">
+        <h5 data-bind="text: authorizationServer.displayName"></h5>
+    </div>
+</div>
+<!-- /ko -->
+
+<div class="row flex flex-row">
+    <div class="col-2">
+        <div class="form-group">
+            <div class="form-group">
+                <label for="username" class="text-monospace form-label">Description</label>
+            </div>
+        </div>
+    </div>
+    <div class="col-6 align-self-center">
+        <div class="form-group">
+            <div class="input-group">
+                <input autocomplete="off" class="form-control form-control-sm" placeholder="value" spellcheck="false"
+                    aria-label="Supported grant flows" readonly
+                    data-bind="textInput: authorizationServer.description">
+                <button class="input-group-addon no-border"
+                    data-bind="copyToClipboard: authorizationServer.description" aria-label="Copy to clipboard">
+                    <i class="icon-emb icon-emb-duplicate"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div class="row flex flex-row">
     <div class="col-2">
         <div class="form-group">
@@ -10,31 +43,10 @@
         <div class="form-group">
             <div class="input-group">
                 <input autocomplete="off" class="form-control form-control-sm" placeholder="value" spellcheck="false"
-                    aria-label="Supported grant flows" readonly data-bind="textInput: $component.displayedGrantFlows()">
+                    aria-label="Supported grant flows" readonly
+                    data-bind="textInput: authorizationServer.displayedGrantTypes">
                 <button class="input-group-addon no-border"
-                    data-bind="copyToClipboard: $component.displayedGrantFlows()" aria-label="Copy to clipboard">
-                    <i class="icon-emb icon-emb-duplicate"></i>
-                </button>
-            </div>
-        </div>
-    </div>
-</div>
-
-<div class="row flex flex-row">
-    <div class="col-2">
-        <div class="form-group">
-            <div class="form-group">
-                <label for="username" class="text-monospace form-label">Client ID</label>
-            </div>
-        </div>
-    </div>
-    <div class="col-6 align-self-center">
-        <div class="form-group">
-            <div class="input-group" data-bind="with: $component.authorizationServer">
-                <input autocomplete="off" class="form-control form-control-sm" placeholder="value" spellcheck="false"
-                    aria-label="Client id" readonly data-bind="textInput: clientId">
-                <button class="input-group-addon no-border" data-bind="copyToClipboard: clientId"
-                    aria-label="Copy to clipboard">
+                    data-bind="copyToClipboard: authorizationServer.displayedGrantTypes" aria-label="Copy to clipboard">
                     <i class="icon-emb icon-emb-duplicate"></i>
                 </button>
             </div>
@@ -55,10 +67,10 @@
             <div class="input-group">
                 <input autocomplete="off" class="form-control form-control-sm" placeholder="value" spellcheck="false"
                     aria-label="Authorization endpoint" readonly
-                    data-bind="textInput: $component.authorizationServer().authorizationEndpoint">
+                    data-bind="textInput: authorizationServer.authorizationEndpoint">
 
                 <button class="input-group-addon no-border"
-                    data-bind="copyToClipboard: $component.authorizationServer().authorizationEndpoint"
+                    data-bind="copyToClipboard: authorizationServer.authorizationEndpoint"
                     aria-label="Copy to clipboard">
                     <i class="icon-emb icon-emb-duplicate"></i>
                 </button>
@@ -79,11 +91,9 @@
         <div class="form-group">
             <div class="input-group">
                 <input autocomplete="off" class="form-control form-control-sm" placeholder="value" spellcheck="false"
-                    aria-label="Token endpoint" readonly
-                    data-bind="textInput: $component.authorizationServer().tokenEndpoint">
+                    aria-label="Token endpoint" readonly data-bind="textInput: authorizationServer.tokenEndpoint">
                 <button class="input-group-addon no-border"
-                    data-bind="copyToClipboard: $component.authorizationServer().tokenEndpoint"
-                    aria-label="Copy to clipboard">
+                    data-bind="copyToClipboard: authorizationServer.tokenEndpoint" aria-label="Copy to clipboard">
                     <i class="icon-emb icon-emb-duplicate"></i>
                 </button>
             </div>
@@ -103,12 +113,13 @@
         <div class="form-group">
             <div class="input-group">
                 <input autocomplete="off" class="form-control form-control-sm" placeholder="value" spellcheck="false"
-                    aria-label="Scopes" readonly data-bind="textInput: $component.displayedScopes">
-                <button class="input-group-addon no-border" data-bind="copyToClipboard: $component.displayedScopes"
-                    aria-label="Copy to clipboard">
+                    aria-label="Scopes" readonly data-bind="textInput: authorizationServer.displayedScopes">
+                <button class="input-group-addon no-border"
+                    data-bind="copyToClipboard: authorizationServer.displayedScopes" aria-label="Copy to clipboard">
                     <i class="icon-emb icon-emb-duplicate"></i>
                 </button>
             </div>
         </div>
     </div>
 </div>
+<!-- /ko -->

--- a/src/components/operations/operation-details/ko/runtime/oauth-server-configuration.ts
+++ b/src/components/operations/operation-details/ko/runtime/oauth-server-configuration.ts
@@ -10,21 +10,17 @@ import { AuthorizationServer } from "../../../../../models/authorizationServer";
 
 export class OauthServerConfiguration {
 
-    public displayedGrantFlows: ko.Observable<string>;
-    public displayedScopes: ko.Observable<string>;
+    public displayServersName: boolean;
 
     constructor() {
-        this.authorizationServer = ko.observable();
-        this.displayedGrantFlows = ko.observable();
-        this.displayedScopes = ko.observable();
+        this.authorizationServers = ko.observable();
     }
 
     @Param()
-    public authorizationServer: ko.Observable<AuthorizationServer>;
+    public authorizationServers: ko.Observable<AuthorizationServer[]>;
 
     @OnMounted()
     public async initialize(): Promise<void> {
-        this.displayedGrantFlows(this.authorizationServer().grantTypes.join(", ").toString());
-        this.displayedScopes(this.authorizationServer().scopes.join(", ").toString());
+        this.displayServersName = this.authorizationServers().length > 1;
     }
 }

--- a/src/components/operations/operation-details/ko/runtime/operation-console.html
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.html
@@ -83,7 +83,7 @@
             <!-- /ko -->
 
             <authorization
-                params="{ api: $component.api, authorizationServer: $component.authorizationServer, consoleOperation: $component.consoleOperation, updateRequestSummary: $component.updateRequestSummary}">
+                params="{ api: $component.api, authorizationServers: $component.authorizationServers, consoleOperation: $component.consoleOperation, updateRequestSummary: $component.updateRequestSummary}">
             </authorization>
 
             <h3>Parameters

--- a/src/components/operations/operation-details/ko/runtime/operation-console.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.ts
@@ -104,7 +104,7 @@ export class OperationConsole {
         this.selectedHostname = ko.observable("");
         this.hostnameSelectionEnabled = ko.observable();
         this.isHostnameWildcarded = ko.computed(() => this.selectedHostname().includes("*"));
-        this.authorizationServer = ko.observable();
+        this.authorizationServers = ko.observable();
 
         this.useCorsProxy = ko.observable(false);
         this.wildcardSegment = ko.observable();
@@ -152,7 +152,7 @@ export class OperationConsole {
     public hostnames: ko.Observable<string[]>;
 
     @Param()
-    public authorizationServer: ko.Observable<AuthorizationServer>;
+    public authorizationServers: ko.Observable<AuthorizationServer[]>;
 
     @Param()
     public useCorsProxy: ko.Observable<boolean>;

--- a/src/components/operations/operation-details/ko/runtime/operation-details.html
+++ b/src/components/operations/operation-details/ko/runtime/operation-details.html
@@ -41,6 +41,14 @@
             <span class="text-monospace text-wrap"
                 data-bind="text: $component.requestUrlSample, attr: { 'data-method': operation().method }"></span>
 
+            <!-- ko if:  apiDocumentationAuthServers()?.length > 0 -->
+            <div class="animation-fade-in">
+                <h4>Authorization</h4>
+                <oauth-server-configuration params="{authorizationServers: apiDocumentationAuthServers}">
+                </oauth-server-configuration>
+            </div>
+            <!-- /ko -->
+
             <!-- ko if: operation().parameters.length > 0 -->
             <h4>Request parameters</h4>
 
@@ -356,14 +364,14 @@
 <!-- ko ifnot: apiType() === 'graphql' -->
 <div class="detachable-right flex-grow animation-fade-in">
     <operation-console class="block scrollable consoles operation-console"
-        params="{ api: api, operation: operation, hostnames: hostnames, authorizationServer: associatedAuthServer, useCorsProxy: useCorsProxy }">
+        params="{ api: api, operation: operation, hostnames: hostnames, authorizationServers: testConsoleAuthServers, useCorsProxy: useCorsProxy }">
     </operation-console>
 </div>
 <!-- /ko -->
 <!-- ko if: apiType() === 'graphql' -->
 <div class="detachable-right graphql-console-width flex-grow animation-fade-in">
     <graphql-console class="flex flex-column consoles" data-bind="dialog: {}"
-        params="{ api: api, hostnames: hostnames, authorizationServer: associatedAuthServer, useCorsProxy: useCorsProxy }">
+        params="{ api: api, hostnames: hostnames, authorizationServers: testConsoleAuthServers, useCorsProxy: useCorsProxy }">
     </graphql-console>
 </div>
 <!-- /ko -->

--- a/src/components/operations/operation-details/ko/runtime/operation-details.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-details.ts
@@ -194,7 +194,7 @@ export class OperationDetails {
 
         let associatedAuthServers: AuthorizationServer[];
         if (api.authenticationSettings?.oAuth2AuthenticationSettings.length > 0) {
-            associatedAuthServers = api.authenticationSettings?.oAuth2AuthenticationSettings.map(x => new AuthorizationServer(x.authorizationServer));
+            associatedAuthServers = await this.oauthService.getOauthServers(api.id);
         }
 
         if (api.authenticationSettings?.openidAuthenticationSettings.length > 0) {

--- a/src/components/operations/operation-details/ko/runtime/operation-details.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-details.ts
@@ -195,9 +195,8 @@ export class OperationDetails {
         let associatedAuthServers: AuthorizationServer[];
         if (api.authenticationSettings?.oAuth2AuthenticationSettings.length > 0) {
             associatedAuthServers = await this.oauthService.getOauthServers(api.id);
-        }
-
-        if (api.authenticationSettings?.openidAuthenticationSettings.length > 0) {
+        } 
+        else if (api.authenticationSettings?.openidAuthenticationSettings.length > 0) {
             associatedAuthServers = await this.oauthService.getOpenIdAuthServers(api.id);
         }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -293,7 +293,7 @@ export enum GrantTypes {
     password = "password"
 }
 
-export const managementApiVersion = "2021-04-01-preview";
+export const managementApiVersion = "2022-04-01-preview";
 
 /**
  * Header name to track developer portal type.

--- a/src/contracts/api.ts
+++ b/src/contracts/api.ts
@@ -1,7 +1,7 @@
 import { AuthenticationSettings } from "./authenticationSettings";
 
 /**
- * Cotract of API
+ * Contract of API
  */
 export interface ApiContract {
     /**

--- a/src/contracts/authenticationSettings.ts
+++ b/src/contracts/authenticationSettings.ts
@@ -1,3 +1,5 @@
+import { AuthorizationServerForClient } from "./authorizationServer";
+
 export interface BearerTokenSendingMethod {
     sendingMethodType: string;
     isChecked: boolean;
@@ -6,6 +8,7 @@ export interface BearerTokenSendingMethod {
 export interface OAuth2AuthenticationSettings {
     authorizationServerId?: string;
     scope?: string;
+    authorizationServer: AuthorizationServerForClient;
 }
 
 export interface OpenIdAuthenticationSettings {
@@ -16,4 +19,6 @@ export interface OpenIdAuthenticationSettings {
 export interface AuthenticationSettings {
     oAuth2?: OAuth2AuthenticationSettings;
     openid?: OpenIdAuthenticationSettings;
+    oAuth2AuthenticationSettings: OAuth2AuthenticationSettings[];
+    openidAuthenticationSettings: OpenIdAuthenticationSettings[];
 }

--- a/src/contracts/authorizationServer.ts
+++ b/src/contracts/authorizationServer.ts
@@ -37,4 +37,14 @@ export interface AuthorizationServerForClient {
      * Example: ["profile", "email"]
      */
     defaultScope: string;
+
+    /**
+     * Is this provider used for the test console?
+     */
+    useInTestConsole: boolean;
+
+    /**
+     * Is this provider used for API documentation?
+     */
+    useInApiDocumentation: boolean;
 }

--- a/src/models/authorizationServer.ts
+++ b/src/models/authorizationServer.ts
@@ -9,6 +9,10 @@ export class AuthorizationServer {
     public tokenEndpoint: string;
     public grantTypes: string[];
     public scopes: string[];
+    public useInTestConsole: boolean;
+    public useInApiDocumentation: boolean;
+    public displayedGrantTypes: string;
+    public displayedScopes: string;
 
     constructor(contract?: AuthorizationServerForClient) {
         if (!contract) {
@@ -22,12 +26,22 @@ export class AuthorizationServer {
         this.authorizationEndpoint = contract.authorizationEndpoint;
         this.tokenEndpoint = contract.tokenEndpoint;
         this.scopes = contract.defaultScope?.split(" ") || [];
+        this.useInApiDocumentation = contract.useInApiDocumentation;
+        this.useInTestConsole = contract.useInTestConsole;
 
         if (!contract.grantTypes) {
             return;
         }
 
         this.grantTypes = this.convertGrantTypes(contract.grantTypes);
+        this.SetDisplayedGrantTypes();
+        this.SetDisplayedScopes();
+    }
+    public SetDisplayedGrantTypes(): void {
+        this.displayedGrantTypes = this.grantTypes.join(", ").toString();
+    }
+    public SetDisplayedScopes(): void {
+        this.displayedScopes = this.scopes?.join(", ").toString();
     }
 
     private convertGrantTypes(grantTypes: string[]): string[] {

--- a/src/models/openIdConnectProvider.ts
+++ b/src/models/openIdConnectProvider.ts
@@ -33,4 +33,13 @@ export class OpenIdConnectProvider {
      */
 
     public clientId: string;
+    /**
+     * Is this provider used for the test console?
+     */
+    useInTestConsole: boolean;
+
+    /**
+     * Is this provider used for API documentation?
+     */
+    useInApiDocumentation: boolean;
 }

--- a/src/services/oauthService.ts
+++ b/src/services/oauthService.ts
@@ -53,6 +53,17 @@ export class OAuthService {
         }
     }
 
+    public async getOauthServers(apiId: string): Promise<AuthorizationServer[]> {
+        try {
+            const authServers = await this.apiClient.get<Page<AuthorizationServerForClient>>(`apis/${apiId}/authServers/oauth2`, [await this.apiClient.getPortalHeader("getAuthorizationServer"), Utils.getIsUserResourceHeader()]);
+            return authServers.value.map(x => new AuthorizationServer(x));
+        }
+        catch (error) {
+            throw new Error(`Unable to fetch configured authorization servers. ${error.stack}`);
+            return undefined;
+        }
+    }
+
     /**
      * Acquires access token using specified grant flow.
      * @param grantType {string} Requested grant type.


### PR DESCRIPTION
This PR introduces displaying the authorization servers specified for an API:

The servers displayed are only the ones that have the property "useInApiDocumentation" set to true.

The properties displayed for the servers in the operation details are the following:
- Name (only if multiple servers are specified) 
- Description 
- Supported grant flows 
- Authorization endpoint URL 
- Token endpoint URL 
- Scopes 

Here is an example of how multiple authorization servers are displayed:
![aaaalign](https://user-images.githubusercontent.com/92857141/194586000-1392e3c1-34f3-4634-aa51-1bc553fe1bf8.png)


The servers used for the test console are the ones that have the property "useInTestConsole" set to true:
In the test console, there is a new selector, where the authorization server can be selected. 
The authentication flow remains the same: when the selected grant type is changed, the authentication flow is initiated.
![multiple-auth-test-console](https://user-images.githubusercontent.com/92857141/180762706-991ea795-2f9a-4a34-9508-03b23deb6843.gif)

