### PR TITLE
Fixed handling of unknown status codes. Added default status text for 529 error.

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/operation-console.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.ts
@@ -515,7 +515,7 @@ export class OperationConsole {
             const knownStatusCode = KnownStatusCodes.find(x => x.code === response.statusCode);
 
             const responseStatusText = response.statusText || knownStatusCode
-                ? knownStatusCode.description
+                ? knownStatusCode?.description
                 : "Unknown";
 
             this.responseStatusCode(response.statusCode.toString());

--- a/src/models/knownStatusCodes.ts
+++ b/src/models/knownStatusCodes.ts
@@ -54,5 +54,6 @@ export const KnownStatusCodes = [
     { code: 507, description: "Insufficient Storage" },
     { code: 508, description: "Loop Detected" },
     { code: 509, description: "Bandwidth Limit Exceeded" },
-    { code: 510, description: "Not Extended" }
+    { code: 510, description: "Not Extended" },
+    { code: 529, description: "Server is overloaded" }
 ];


### PR DESCRIPTION
The Test console could not handle status codes that weren't explicitly defined.