### PR TITLE
Fixed the build script for FuncApp-based publisher example.

### DIFF
--- a/examples/publisher/azure-function/publish/index.ts
+++ b/examples/publisher/azure-function/publish/index.ts
@@ -5,11 +5,13 @@ import { InversifyInjector } from "@paperbits/common/injection";
 import { IPublisher } from "@paperbits/common/publishing";
 import { CoreModule } from "@paperbits/core/core.module";
 import { CorePublishModule } from "@paperbits/core/core.publish.module";
+import { FormsModule } from "@paperbits/forms/forms.module";
 import { ApimPublishModule } from "../../../../src/apim.publish.module";
 import { StylePublishModule } from "@paperbits/styles/styles.publish.module";
 import { ProseMirrorModule } from "@paperbits/prosemirror/prosemirror.module";
 import { ConsoleLogger } from "@paperbits/common/logging";
 import { StaticSettingsProvider } from "../../../../src/components/staticSettingsProvider";
+import { PublishingCacheModule } from "../../../../src/persistence/publishingCacheModule";
 
 
 export async function publish(): Promise<void> {
@@ -40,9 +42,11 @@ export async function publish(): Promise<void> {
     injector.bindModule(new CorePublishModule());
     injector.bindModule(new StylePublishModule());
     injector.bindModule(new ProseMirrorModule());
+    injector.bindModule(new FormsModule());
     injector.bindModule(new ApimPublishModule());
     injector.bindInstance("settingsProvider", settingsProvider);
     injector.bindInstance("outputBlobStorage", outputBlobStorage);
+    injector.bindModule(new PublishingCacheModule());
     injector.resolve("autostart");
 
     const publisher = injector.resolve<IPublisher>("sitePublisher");

--- a/webpack.function.js
+++ b/webpack.function.js
@@ -26,11 +26,10 @@ const functionConfig = {
     optimization: {
         minimizer: [
             new TerserPlugin({
-                sourceMap: false,
                 terserOptions: {
                     mangle: false,
                     output: {
-                        comments: false,
+                        comments: false
                     }
                 }
             })
@@ -56,25 +55,38 @@ const functionConfig = {
             },
             {
                 test: /\.html$/,
-                loader: "html-loader?exportAsEs6Default"
+                loader: "html-loader",
+                options: {
+                    esModule: true,
+                    sources: false,
+                    minimize: {
+                        removeComments: false,
+                        collapseWhitespace: false
+                    }
+                }
             },
             {
                 test: /\.(png|woff|woff2|eot|ttf|svg)$/,
-                loader: "url-loader?limit=100000"
+                loader: "url-loader",
+                options: {
+                    limit: 10000
+                }
             },
             {
-                test: /\.liquid$/,
+                test: /\.(raw|liquid)$/,
                 loader: "raw-loader"
             }
         ]
     },
     plugins: [
         new MiniCssExtractPlugin({ filename: "[name].css", chunkFilename: "[id].css" }),
-        new CopyWebpackPlugin([
-            { from: `./examples/function`, to: `./` },
-            { from: `./src/config.publish.json`, to: `./publish/config.json` },
-            { from: `./src/themes/website/styles/fonts`, to: "publish/assets/styles/fonts" }
-        ]),
+        new CopyWebpackPlugin({
+            patterns: [
+                { from: `./examples/function`, to: `./` },
+                { from: `./src/config.publish.json`, to: `./publish/config.json` },
+                { from: `./src/themes/website/styles/fonts`, to: "publish/assets/styles/fonts" }
+            ]
+        }),
         new webpack.DefinePlugin({
             "process.env.NODE_ENV": JSON.stringify("production")
         })


### PR DESCRIPTION
The build script for FuncApp-based publisher example got outdated (was built for Webpack 3.x versions).