### PR TITLE
Implemented the display of security schemes as they are in OpenAPI

### DIFF
--- a/src/apim.runtime.module.ts
+++ b/src/apim.runtime.module.ts
@@ -37,7 +37,7 @@ import { GraphqlConsole } from "./components/operations/operation-details/ko/run
 import { GraphqlDocumentation } from "./components/operations/operation-details/ko/runtime/graphql-documentation/graphql-doc";
 import { GraphqlDetails } from "./components/operations/operation-details/ko/runtime/graphql-documentation/graphql-doc-details";
 import { GraphDocService } from "./components/operations/operation-details/ko/runtime/graphql-documentation/graphql-doc-service";
-import { OauthServerConfiguration } from "./components/operations/operation-details/ko/runtime/oauth-server-configuration";
+import { SecuritySchemes } from "./components/operations/operation-details/ko/runtime/security-schemes";
 import { OperationConsole } from "./components/operations/operation-details/ko/runtime/operation-console";
 import { OperationDetails } from "./components/operations/operation-details/ko/runtime/operation-details";
 import { TypeDefinitionViewModel } from "./components/operations/operation-details/ko/runtime/type-definition";
@@ -159,7 +159,7 @@ export class ApimRuntimeModule implements IInjectorModule {
         injector.bind("tagInput", TagInput);
         injector.bindToCollection("autostart", AccessTokenRefrsher);
         injector.bind("pagination", Pagination);
-        injector.bind("oauthServerConfiguration", OauthServerConfiguration);
+        injector.bind("securitySchemes", SecuritySchemes);
         injector.bindModule(new CustomWidgetRuntimeModule());
         injector.bindSingleton("delegationService", DelegationService);
         injector.bindModule(new RoleBasedSecurityRuntimeModule());

--- a/src/components/operations/operation-details/ko/runtime/apiKeyDetails.ts
+++ b/src/components/operations/operation-details/ko/runtime/apiKeyDetails.ts
@@ -1,0 +1,9 @@
+export enum ApiKeyLocation {
+    Query = "query",
+    Header = "header"
+}
+
+export interface ApiKeyDetails {
+    in: string;
+    name: string;
+}

--- a/src/components/operations/operation-details/ko/runtime/operation-details.html
+++ b/src/components/operations/operation-details/ko/runtime/operation-details.html
@@ -43,9 +43,9 @@
 
             <!-- ko if:  apiDocumentationAuthServers()?.length > 0 -->
             <div class="animation-fade-in">
-                <h4>Authorization</h4>
-                <oauth-server-configuration params="{authorizationServers: apiDocumentationAuthServers}">
-                </oauth-server-configuration>
+                <h4>Security Schemes</h4>
+                <security-schemes params="{authorizationServers: apiDocumentationAuthServers, apiKeyDetails: apiKeyDetails}">
+                </security-schemes>
             </div>
             <!-- /ko -->
 

--- a/src/components/operations/operation-details/ko/runtime/security-schemes.html
+++ b/src/components/operations/operation-details/ko/runtime/security-schemes.html
@@ -1,5 +1,49 @@
-<!-- ko foreach: { data: authorizationServers, as: 'authorizationServer' } -->
 
+<h5>ApiKeyAuth:</h5>
+
+<div class="row flex flex-row align-items-center">
+    <div class="col-2">
+        <div class="form-group">
+            <label class="text-monospace form-label">Name</label>
+        </div>
+    </div>
+    <div class="col-6">
+        <div class="form-group">
+            <div class="input-group">
+                <input autocomplete="off" class="form-control form-control-sm" placeholder="value" spellcheck="false"
+                    aria-label="Name" readonly data-bind="textInput: apiKeyDetails.name">
+                <button class="input-group-addon no-border" data-bind="copyToClipboard: apiKeyDetails.name"
+                    aria-label="Copy to clipboard">
+                    <i class="icon-emb icon-emb-duplicate"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row flex flex-row align-items-center">
+    <div class="col-2">
+        <div class="form-group">
+            <label class="text-monospace form-label">In</label>
+        </div>
+    </div>
+    <div class="col-6">
+        <div class="form-group">
+            <div class="input-group">
+                <input autocomplete="off" class="form-control form-control-sm" placeholder="value" spellcheck="false"
+                    aria-label="In" readonly data-bind="textInput: apiKeyDetails.in">
+                <button class="input-group-addon no-border" data-bind="copyToClipboard: apiKeyDetails.in"
+                    aria-label="Copy to clipboard">
+                    <i class="icon-emb icon-emb-duplicate"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<h5>OAuth 2:</h5>
+
+<!-- ko foreach: { data: authorizationServers, as: 'authorizationServer' } -->
 <!-- ko if: $component.displayServersName -->
 <div class="row flex flex-row">
     <div class="col-auto">

--- a/src/components/operations/operation-details/ko/runtime/security-schemes.ts
+++ b/src/components/operations/operation-details/ko/runtime/security-schemes.ts
@@ -17,8 +17,6 @@ export class SecuritySchemes {
         this.authorizationServers = ko.observable();
     }
 
-
-    //create a new param for apiKeyDetails
     @Param()
     public apiKeyDetails: ko.Observable<ApiKeyDetails>;
 

--- a/src/components/operations/operation-details/ko/runtime/security-schemes.ts
+++ b/src/components/operations/operation-details/ko/runtime/security-schemes.ts
@@ -1,20 +1,26 @@
 import * as ko from "knockout";
-import template from "./oauth-server-configuration.html";
+import template from "./security-schemes.html";
 import { Component, OnMounted, Param } from "@paperbits/common/ko/decorators";
 import { AuthorizationServer } from "../../../../../models/authorizationServer";
+import { ApiKeyDetails } from "./apiKeyDetails";
 
 @Component({
-    selector: "oauth-server-configuration",
+    selector: "security-schemes",
     template: template,
 })
 
-export class OauthServerConfiguration {
+export class SecuritySchemes {
 
     public displayServersName: boolean;
 
     constructor() {
         this.authorizationServers = ko.observable();
     }
+
+
+    //create a new param for apiKeyDetails
+    @Param()
+    public apiKeyDetails: ko.Observable<ApiKeyDetails>;
 
     @Param()
     public authorizationServers: ko.Observable<AuthorizationServer[]>;

--- a/src/themes/website/styles/docs.scss
+++ b/src/themes/website/styles/docs.scss
@@ -220,7 +220,7 @@ validation-summary {
     }
 }
 
-oauth-server-configuration {
+security-schemes {
     .form-control {
         margin: 0;
     }


### PR DESCRIPTION
Below is an example of how the Security Schemes are displayed:

![image](https://user-images.githubusercontent.com/92857141/206745440-ae13ca3c-ca52-41d5-b727-93ccc02b4ced.png)
