### PR TITLE
Added condition to getResourceName function utility to remove "operations/" from name before returning

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,8 +13,11 @@ export class Utils {
         if (matches && matches.length > 1) {
             switch (resultType) {
                 case "name":
+                    // Removes operations/ from name in case of API names "operations"
+                    if (matches[1].includes('operations/')) {
+                        return matches[1].replace('operations/', '');
+                    }
                     return matches[1];
-
                 case "shortId":
                     return `/${resource}/${matches[1]}`;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ export class Utils {
         if (matches && matches.length > 1) {
             switch (resultType) {
                 case "name":
-                    // Removes operations/ from name in case of API names "operations"
+                    // Removes "operations/"" from name in case of API named "operations"
                     if (matches[1].includes('operations/')) {
                         return matches[1].replace('operations/', '');
                     }


### PR DESCRIPTION
This PR includes an edit to the getResourceName function in file Utils.ts to fix the associated issue(#2112).

It allows the developer portal to correctly resolve operations' names for operations in the case of an API named "operations".