### PR TITLE
Fixed: product name disappears when changing subscription

### DIFF
--- a/src/components/users/subscriptions/ko/runtime/subscriptions.ts
+++ b/src/components/users/subscriptions/ko/runtime/subscriptions.ts
@@ -101,6 +101,10 @@ export class Subscriptions {
     }
 
     private syncSubscriptionLabelState(subscription: SubscriptionListItem, updatedVM: SubscriptionListItem): void {
+        if(updatedVM.model.productName === undefined) {
+            updatedVM.model.productName = subscription.model.productName;
+        }
+
         if (subscription.primaryKeyBtnLabel() !== updatedVM.primaryKeyBtnLabel()) {
             updatedVM.togglePrimaryKey();
         }


### PR DESCRIPTION
## Problem
when changing a subscription (regenerate/rename) the product name disappears.
![subscription_product_disappear](https://user-images.githubusercontent.com/92857141/221874613-955c2836-a434-4be0-86dc-74bc2cedf11d.gif)


## Solution
When syncing with the new updated subscription, populate the product name again.