### PR TITLE
Added pagination for user subscriptions

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/operation-details.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-details.ts
@@ -360,7 +360,7 @@ export class OperationDetails {
 
                 const contentTypeObj = {}
                 Object.entries(valueObj).forEach(([key, val]) => {
-                    if (typeof val === 'object') return
+                    if (typeof val === "object") return
                     contentTypeObj[key] = val.toString();
                 })
 

--- a/src/components/users/subscriptions/ko/runtime/subscriptions.html
+++ b/src/components/users/subscriptions/ko/runtime/subscriptions.html
@@ -7,6 +7,12 @@
             <div role="columnheader" class="col-1 text-truncate">Action</div>
         </div>
     </div>
+    <!-- ko if: working -->
+    <div class="table-body">
+        <spinner></spinner>
+    </div>
+    <!-- /ko -->
+    <!-- ko ifnot: working -->
     <div role="rowgroup" class="table-body">
         <!-- ko if: subscriptions().length === 0 -->
         <div role="row" class="table-row">
@@ -32,7 +38,8 @@
 
                             <!-- ko if: $data.isEdit -->
                             <div class="input-group has-validation">
-                                <input type="text" class="form-control" data-bind="value: editName" aria-required="true" />
+                                <input type="text" class="form-control" data-bind="value: editName"
+                                    aria-required="true" />
                                 <span class="invalid-feedback" data-bind="validationMessage: editName"></span>
                             </div>
                             <!-- /ko -->
@@ -145,4 +152,9 @@
         <!-- /ko -->
         <!-- /ko -->
     </div>
+
+    <!-- ko if: $component.totalPages() > 1 -->
+    <pagination params="{ pageNumber: $component.pageNumber, totalPages: $component.totalPages }"></pagination>
+    <!-- /ko -->
+    <!-- /ko -->
 </div>

--- a/src/models/console/consoleOperation.ts
+++ b/src/models/console/consoleOperation.ts
@@ -110,7 +110,7 @@ export class ConsoleOperation {
         }
 
         let requestUrl = this.urlTemplate;
-        let parameters = this.templateParameters().concat(this.request.queryParameters());
+        const parameters = this.templateParameters().concat(this.request.queryParameters());
 
         const wildcardName = "{*}"
         requestUrl = requestUrl.replace("*", wildcardName);

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -102,16 +102,27 @@ export class ProductService {
      * Returns user subscriptions with product name.
      * @param userId {string} User unique identifier.
      */
-    public async getUserSubscriptionsWithProductName(userId: string): Promise<Subscription[]> {
+    public async getUserSubscriptionsWithProductName(userId: string, searchRequest?: SearchQuery): Promise<Page<Subscription>> {
         if (!userId) {
             throw new Error(`Parameter "userId" not specified.`);
         }
 
+        const skip = searchRequest && searchRequest.skip || 0;
+        const take = searchRequest && searchRequest.take || Constants.defaultPageSize;
+
+        let query = `${userId}/subscriptions?$top=${take}&$skip=${skip}`;
+
+
         const result = [];
-        const pageOfSubscriptions = await this.mapiClient.get<Page<SubscriptionContract>>(`${userId}/subscriptions`, [await this.mapiClient.getPortalHeader("getUserSubscriptions")]);
+        const pageOfSubscriptions = await this.mapiClient.get<Page<SubscriptionContract>>(query, [await this.mapiClient.getPortalHeader("getUserSubscriptions")]);
+
+        const page = new Page<Subscription>();
+        page.count = pageOfSubscriptions.count;
+        page.nextLink = pageOfSubscriptions.nextLink;
+        page.value = result;
 
         if (!pageOfSubscriptions?.value) {
-            return result;
+            return page;
         }
 
         const subscriptions = pageOfSubscriptions.value;
@@ -159,7 +170,7 @@ export class ProductService {
 
         await Promise.all(promises);
 
-        return result;
+        return page;
     }
 
     /**

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -109,9 +109,7 @@ export class ProductService {
 
         const skip = searchRequest && searchRequest.skip || 0;
         const take = searchRequest && searchRequest.take || Constants.defaultPageSize;
-
-        let query = `${userId}/subscriptions?$top=${take}&$skip=${skip}`;
-
+        const query = `${userId}/subscriptions?$top=${take}&$skip=${skip}`;
 
         const result = [];
         const pageOfSubscriptions = await this.mapiClient.get<Page<SubscriptionContract>>(query, [await this.mapiClient.getPortalHeader("getUserSubscriptions")]);


### PR DESCRIPTION
### Problem 
User subscriptions widget can only display a maximum of 100 subscriptions, with no option to see more subscriptions (in case the user has more than 100).

### Solution
Added pagination for user subscriptions.

Closes #2100 