### PR TITLE
Replace deprecated methods from cred generation

### DIFF
--- a/src/components/users/change-password/ko/runtime/change-password.ts
+++ b/src/components/users/change-password/ko/runtime/change-password.ts
@@ -113,7 +113,7 @@ export class ChangePassword {
         }
 
         const user = await this.usersService.getCurrentUser();
-        const credentials = `Basic ${btoa(`${user.email}:${this.password()}`)}`;
+        const credentials = `Basic ${Buffer.from(`${user.email}:${this.password()}`, 'utf8').toString('base64')}`;
         let userId = await this.usersService.authenticate(credentials);
 
         if (!userId) {

--- a/src/components/users/change-password/ko/runtime/change-password.ts
+++ b/src/components/users/change-password/ko/runtime/change-password.ts
@@ -113,7 +113,7 @@ export class ChangePassword {
         }
 
         const user = await this.usersService.getCurrentUser();
-        const credentials = `Basic ${Buffer.from(`${user.email}:${this.password()}`, 'utf8').toString('base64')}`;
+        const credentials = `Basic ${Buffer.from(`${user.email}:${this.password()}`, "utf8").toString("base64")}`;
         let userId = await this.usersService.authenticate(credentials);
 
         if (!userId) {

--- a/src/services/usersService.ts
+++ b/src/services/usersService.ts
@@ -33,7 +33,7 @@ export class UsersService {
      * @param password {string} Password.
      */
     public async signInWithBasic(username: string, password: string): Promise<void> {
-        const credentials = `Basic ${Buffer.from(`${username}:${password}`, 'utf8').toString('base64')}`;
+        const credentials = `Basic ${Buffer.from(`${username}:${password}`, "utf8").toString("base64")}`;
         const userId = await this.authenticate(credentials);
 
         if (userId) {

--- a/src/services/usersService.ts
+++ b/src/services/usersService.ts
@@ -33,7 +33,7 @@ export class UsersService {
      * @param password {string} Password.
      */
     public async signInWithBasic(username: string, password: string): Promise<void> {
-        const credentials = `Basic ${btoa(`${username}:${password}`)}`;
+        const credentials = `Basic ${Buffer.from(`${username}:${password}`, 'utf8').toString('base64')}`;
         const userId = await this.authenticate(credentials);
 
         if (userId) {


### PR DESCRIPTION
Replace the deprecated methods of cred generation. 
Instead use Buffer.from()