### PR TITLE
fix typos and spelling errors

### DIFF
--- a/js/HipObject.js
+++ b/js/HipObject.js
@@ -2,7 +2,7 @@
 // and callback functions for displaying items outside the control.
 
 //-------------------------------------------------------------------------------------------------
-// The following varible name is defined by partner
+// The following variable name is defined by partner
 // Make sure it has no conflicts to any other your variable names.
 // The name defined here influence how to generate get hip URL that has format "http://p.client.hip.live.com/GetHIP/GetWLSPHIP0/<the namedefined here>?". 
 // Replace '<   >' there with the name here.  

--- a/src/bindingHandlers/fastForeach.ts
+++ b/src/bindingHandlers/fastForeach.ts
@@ -320,7 +320,7 @@ FastForEach.prototype.getPendingDeleteFor = function (data) {
     return this.pendingDeletes[index];
 };
 
-// tries to find the existing pending delete info for this data item, and if it can't, it registeres one
+// tries to find the existing pending delete info for this data item, and if it can't, it registers one
 FastForEach.prototype.getOrCreatePendingDeleteFor = function (data) {
     let pd = this.getPendingDeleteFor(data);
     if (pd) {

--- a/src/components/apis/details-of-api/detailsOfApiContract.ts
+++ b/src/components/apis/details-of-api/detailsOfApiContract.ts
@@ -3,7 +3,7 @@ import { HyperlinkContract } from "@paperbits/common/editing";
 
 export interface DetailsOfApiContract extends Contract {
     /**
-     * Link to a page that contains API changlog.
+     * Link to a page that contains API changelog.
      */
     changeLogPageHyperlink?: HyperlinkContract;
 }

--- a/src/components/help/hint.ts
+++ b/src/components/help/hint.ts
@@ -1,5 +1,5 @@
 /**
- * Entity describing the issue and its potential soultion.
+ * Entity describing the issue and its potential solution.
  */
 export interface Hint {
     /**
@@ -8,7 +8,7 @@ export interface Hint {
     issue: string;
 
     /**
-     * Free text explaning what can be done to resolve this issue.
+     * Free text explaining what can be done to resolve this issue.
      */
     suggestion: string;
 }

--- a/src/components/reports/ko/runtime/reportRecordByOperationViewModel.ts
+++ b/src/components/reports/ko/runtime/reportRecordByOperationViewModel.ts
@@ -5,7 +5,7 @@ import * as ko from "knockout";
  */
 export class ReportRecordByOperationViewModel {
     /**
-     * Operaion identifier, e.g. "/apis/httpbin/operations/get".
+     * Operation identifier, e.g. "/apis/httpbin/operations/get".
      */
     public operationId: ko.Observable<string>;
 

--- a/src/components/reports/ko/runtime/reports.ts
+++ b/src/components/reports/ko/runtime/reports.ts
@@ -455,7 +455,7 @@ export class Reports {
         this.reportByCallsGeo(chartConfigCallsGeo);
 
 
-        /* Bandwith */
+        /* Bandwidth */
         const recordsBandwidth: BarChartRecord[] = reportsByTime.value.map(x => {
             return {
                 timestamp: new Date(x.timestamp),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -102,7 +102,7 @@ export const reservedPermalinks = [
 ];
 
 /**
- * Maximum number of items to request from Managament API.
+ * Maximum number of items to request from Management API.
  */
 export const defaultPageSize = 50;
 

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -248,7 +248,7 @@ export class ApiService {
 
     /**
      * Returns API with specified ID and revision.
-     * @param apiId Unique API indentifier.
+     * @param apiId Unique API identifier.
      * @param revision
      */
     public async getApi(apiId: string, revision?: string): Promise<Api> {
@@ -399,7 +399,7 @@ export class ApiService {
     }
 
     /**
-     * Returns API schema with sepcified identifier.
+     * Returns API schema with specified identifier.
      * @param schemaId {string} ARM-formatted schema identifier.
      */
     public async getApiSchema(schemaId: string): Promise<Schema> {

--- a/src/services/provisioningService.ts
+++ b/src/services/provisioningService.ts
@@ -30,7 +30,7 @@ export class ProvisionService {
         const accessToken = await this.authenticator.getAccessTokenAsString();
 
         if (!accessToken) {
-            this.viewManager.notifyError(`Unable to setup website`, `Management API access token is empty or invald.`);
+            this.viewManager.notifyError(`Unable to setup website`, `Management API access token is empty or invalid.`);
         }
 
         for (const key of keys) {

--- a/src/startup.publish.ts
+++ b/src/startup.publish.ts
@@ -49,7 +49,7 @@ injector.resolve("autostart");
 /* Allowing self-signed certificates for HTTP requests */
 process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = "0";
 
-/* Bulding dependency injection container */
+/* Building dependency injection container */
 const publisher = injector.resolve<IPublisher>("sitePublisher");
 
 /* Running actual publishing */


### PR DESCRIPTION
Fixing some minor typos and spelling errors which should not affect functionality but improve the overall quality of documentation.