### PR TITLE
Removed menu styles from test console

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/graphql-console.html
+++ b/src/components/operations/operation-details/ko/runtime/graphql-console.html
@@ -154,7 +154,7 @@
             </div>
         </div>
 
-        <div class="panel panel-dark panel-highlight flex-item flex-grow menu menu-horizontal">
+        <div class="panel panel-dark panel-highlight flex-item flex-grow">
 
             <div class="gql-container" data-bind="css: { 'ws-responses': displayWsConsole }">
                 <div class="gql-explorer-grid">

--- a/src/components/operations/operation-details/ko/runtime/operation-console.html
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.html
@@ -364,7 +364,7 @@
         </div>
 
         <!-- ko ifnot: api().type === 'websocket' -->
-        <div class="panel panel-dark panel-highlight flex-item flex-grow menu menu-horizontal">
+        <div class="panel panel-dark panel-highlight flex-item flex-grow">
             <details open class="details-styled">
                 <summary aria-label="HTTP request">
                     <h3>
@@ -409,7 +409,7 @@
         <!-- /ko -->
 
         <!-- ko if: api().type === 'websocket' -->
-        <div class="panel panel-dark panel-highlight flex-item flex-grow menu menu-horizontal">
+        <div class="panel panel-dark panel-highlight flex-item flex-grow">
             <details open class="details-styled">
                 <summary aria-label="WebSocket request">
                     <h3>
@@ -540,7 +540,7 @@
         <!-- /ko -->
 
         <!-- ko if: responseStatusCode -->
-        <div class="panel panel-dark menu menu-horizontal" data-bind="scrollintoview: {}">
+        <div class="panel panel-dark" data-bind="scrollintoview: {}">
 
             <h3>HTTP response</h3>
             <pre><span>HTTP/1.1</span> <span data-bind="attr: { 'data-code': responseStatusCode  }"><span data-bind="text: responseStatusCode, attr: { 'data-code':responseStatusCode  }"></span> <span data-bind="text: responseStatusText"></span></span>


### PR DESCRIPTION
### Problem
The style applied for "menu" from the style guide is also applied for the test console panel. This creates confusion, as it is not clear where the style from the console comes from.

### Solution
Removed the CSS classes specific for menu from the test console.