### PR TITLE
Fixed scroll to operation

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/operation-details.html
+++ b/src/components/operations/operation-details/ko/runtime/operation-details.html
@@ -9,7 +9,7 @@
 <div class="animation-fade-in">
     <div class="row flex flex-row">
         <div class="col-md-11  text-wrap">
-            <h2 class="operation-name">
+            <h2 id="operation-name">
                 <span data-bind="text: operation().displayName"></span>
             </h2>
         </div>
@@ -294,7 +294,7 @@
 <!-- ko if: operation -->
 <div class="animation-fade-in row flex flex-row">
     <div class="col-md-11 text-wrap">
-        <h2 class="operation-name">
+        <h2 id="operation-name">
             <span data-bind="text: operation().displayName"></span>
         </h2>
     </div>
@@ -335,7 +335,7 @@
 <div class="animation-fade-in">
     <div class="row flex flex-row">
         <div class="col-md-11 text-wrap">
-            <h2>GraphQL endpoint</h2>
+            <h2 id="operation-name">GraphQL endpoint</h2>
             <span class="monospace" data-bind="text: $component.requestUrlSample"></span>
         </div>
         <!-- ko if: $component.enableConsole -->

--- a/src/components/operations/operation-details/ko/runtime/operation-details.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-details.ts
@@ -147,6 +147,7 @@ export class OperationDetails {
     public async initialize(): Promise<void> {
         const apiName = this.routeHelper.getApiName();
         const operationName = this.routeHelper.getOperationName();
+        const graphName = this.routeHelper.getGraphName();
 
         this.selectedApiName(apiName);
         this.selectedOperationName(operationName);
@@ -158,11 +159,20 @@ export class OperationDetails {
         if (operationName) {
             await this.loadOperation(apiName, operationName);
         }
+
+        if (this.enableScrollTo && (operationName || graphName)) {
+            this.scrollToOperation();
+        }
     }
 
     private async onRouteChange(): Promise<void> {
         const apiName = this.routeHelper.getApiName();
         const operationName = this.routeHelper.getOperationName();
+        const graphName = this.routeHelper.getGraphName();
+
+        if (this.enableScrollTo && (operationName || graphName)) {
+            this.scrollToOperation();
+        }
 
         if (apiName && apiName !== this.selectedApiName()) {
             this.selectedApiName(apiName);
@@ -232,11 +242,6 @@ export class OperationDetails {
         this.tags(operationTags.map(tag => tag.name));
 
         this.working(false);
-
-        if (this.enableScrollTo) {
-            const headerElement = document.querySelector(".operation-name");
-            headerElement && headerElement.scrollIntoView({ behavior: "smooth", block: "start", inline: "start" });
-        }
     }
 
     public async loadDefinitions(operation: Operation): Promise<void> {
@@ -421,6 +426,11 @@ export class OperationDetails {
         const operationName = this.operation().name;
 
         return this.routeHelper.getDefinitionAnchor(apiName, operationName, definition.name);
+    }
+
+    private scrollToOperation() {
+        const headerElement = document.getElementById("operation-name");
+        headerElement && headerElement.scrollIntoView({ behavior: "smooth", block: "start", inline: "start" });
     }
 
     @OnDestroyed()

--- a/src/components/operations/operation-details/ko/runtime/operation-details.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-details.ts
@@ -234,7 +234,7 @@ export class OperationDetails {
         this.working(false);
 
         if (this.enableScrollTo) {
-            const headerElement = document.querySelector(".operation-header");
+            const headerElement = document.querySelector(".operation-name");
             headerElement && headerElement.scrollIntoView({ behavior: "smooth", block: "start", inline: "start" });
         }
     }


### PR DESCRIPTION
### Problem
"Automatically scroll to operation name" setting from Operation Details widget doesn't have any effect.

### Solution
When this setting is set to true, check if there is an operation or graph selected and scroll to it, in case there is.