### PR TITLE
Subscription key improvements

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/authorization.html
+++ b/src/components/operations/operation-details/ko/runtime/authorization.html
@@ -11,12 +11,12 @@
     <div class="row flex flex-row">
         <div class="col-4">
             <label for="authServer" class="text-monospace form-label"
-                   data-bind="text: $component.authorizationServer().displayName"></label>
+                data-bind="text: $component.authorizationServer().displayName"></label>
         </div>
         <div class="col-7">
             <div class="form-group">
                 <select id="authServer" class="form-control"
-                        data-bind="options: $component.authorizationServer().grantTypes, value: $component.selectedGrantType, optionsCaption: 'No auth'">
+                    data-bind="options: $component.authorizationServer().grantTypes, value: $component.selectedGrantType, optionsCaption: 'No auth'">
                 </select>
             </div>
         </div>
@@ -49,7 +49,7 @@
         <div class="col-7">
             <div class="form-group">
                 <button class="button button-primary"
-                        data-bind="click: $component.authenticateOAuthWithPassword">Authorize</button>
+                    data-bind="click: $component.authenticateOAuthWithPassword">Authorize</button>
             </div>
         </div>
     </div>
@@ -79,8 +79,15 @@
                 </select>
                 <!-- /ko -->
                 <!-- ko if: !$component.products() || $component.products().length === 0 -->
-                <input id="subscriptionKey" type="text" class="form-control" placeholder="subscription key"
-                       data-bind="textInput: $component.selectedSubscriptionKey" />
+                <div class="input-group">
+                    <input id="subscriptionKey" class="form-control" placeholder="subscription key"
+                        data-bind="textInput: $component.selectedSubscriptionKey, attr: { type: subscriptionKeyRevealed() ? 'text' : 'password' }"
+                        aria-required="true" />
+                    <button data-bind="click: toggleSubscriptionKey" class="input-group-addon">
+                        <i
+                            data-bind="class: subscriptionKeyRevealed() ? 'icon-emb icon-emb-eye-fill' :'icon-emb icon-emb-eye'"></i>
+                    </button>
+                </div>
                 <!-- /ko -->
             </div>
         </div>

--- a/src/components/operations/operation-details/ko/runtime/graphql-console.html
+++ b/src/components/operations/operation-details/ko/runtime/graphql-console.html
@@ -50,7 +50,8 @@
                                         <input type="text" autocomplete="off" class="form-control form-control-sm"
                                             placeholder="name" spellcheck="false" aria-label="Parameter name"
                                             data-bind="textInput: parameter.name, attr:{ 'readonly': parameter.required }">
-                                        <span class="invalid-feedback" data-bind="validationMessage: parameter.name"></span>
+                                        <span class="invalid-feedback"
+                                            data-bind="validationMessage: parameter.name"></span>
                                     </div>
                                 </div>
                             </div>
@@ -68,8 +69,8 @@
                                             data-bind="textInput: parameter.value, attr:{ 'aria-required': parameter.required }">
                                         <!-- /ko -->
                                         <!-- ko if: parameter.secret-->
-                                        <input autocomplete="off" class="form-control form-control-sm" placeholder="value"
-                                            spellcheck="false" aria-label="Parameter value"
+                                        <input autocomplete="off" class="form-control form-control-sm"
+                                            placeholder="value" spellcheck="false" aria-label="Parameter value"
                                             data-bind=" attr: {type: parameter.inputType, 'aria-required': parameter.required }, textInput: parameter.value">
                                         <button data-bind="click: () => $component.toggleSecretParameter(parameter)"
                                             class="input-group-addon">
@@ -77,6 +78,8 @@
                                                 data-bind="class: parameter.revealed() ? 'icon-emb icon-emb-eye-fill' :'icon-emb icon-emb-eye'"></i>
                                         </button>
                                         <!-- /ko -->
+                                        <span class="invalid-feedback"
+                                            data-bind="validationMessage: parameter.value"></span>
                                         <!-- /ko -->
                                     </div>
                                 </div>
@@ -115,7 +118,8 @@
                                         <input type="text" autocomplete="off" class="form-control form-control-sm"
                                             placeholder="name" spellcheck="false" aria-label="Header name"
                                             data-bind="textInput: header.name, attr: { 'readonly': header.required }">
-                                        <span class="invalid-feedback" data-bind="validationMessage: header.name"></span>
+                                        <span class="invalid-feedback"
+                                            data-bind="validationMessage: header.name"></span>
                                     </div>
                                 </div>
                             </div>
@@ -130,7 +134,8 @@
                                         <input type="text" autocomplete="off" class="form-control form-control-sm"
                                             placeholder="value" spellcheck="false" aria-label="Header value"
                                             data-bind="textInput: header.value, attr: { 'aria-required': header.required }">
-                                        <span class="invalid-feedback" data-bind="validationMessage: header.value"></span>
+                                        <span class="invalid-feedback"
+                                            data-bind="validationMessage: header.value"></span>
                                     </div>
                                     <!-- /ko -->
                                 </div>
@@ -199,11 +204,11 @@
                     <div class="flex flex-column align-items-end">
 
                         <!-- ko if: hasErrorEditors() -->
-                        <div class="panel panel-dark animation-fade-in gql-editor-errors"
+                        <div class="alert alert-danger animation-fade-in gql-editor-errors"
                             data-bind="scrollintoview: {}">
                             <p>Unable to send the request</p>
                             <!-- ko foreach: { data: editorErrors, as: 'error' } -->
-                            <p class="text-muted mb-unset" data-bind="html: error"></p>
+                            <p data-bind="html: error"></p>
                             <!-- /ko -->
                         </div>
                         <!-- /ko -->

--- a/src/components/operations/operation-details/ko/runtime/graphql-console.ts
+++ b/src/components/operations/operation-details/ko/runtime/graphql-console.ts
@@ -111,6 +111,14 @@ export class GraphqlConsole {
         this.wsProcessing = ko.observable(false);
         this.displayWsConsole = ko.observable(false);
         this.wsLogItems = ko.observableArray([]);
+
+        validation.registerExtenders();
+
+        validation.init({
+            insertMessages: false,
+            errorElementClass: "is-invalid",
+            decorateInputElement: true
+        });
     }
 
     @Param()
@@ -286,12 +294,14 @@ export class GraphqlConsole {
 
     public async validateAndSendRequest(): Promise<void> {
         const headers = this.headers();
-        const parameters = [].concat(headers);
+        const queryParameters = this.queryParameters();
+        const parameters = [].concat(headers, queryParameters);
         const validationGroup = validation.group(parameters.map(x => x.value), { live: true });
         const clientErrors = validationGroup();
 
         if (clientErrors.length > 0) {
             validationGroup.showAllMessages();
+            this.editorErrors.push("Required fields are missing or incomplete. Please review the request and ensure all required information is provided. Look for highlighted areas with error indicators.");
             return;
         }
 

--- a/src/components/operations/operation-details/ko/runtime/operation-console.html
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.html
@@ -112,7 +112,8 @@
                                     <input type="text" autocomplete="off" class="form-control form-control-sm"
                                         placeholder="value" spellcheck="false" aria-label="Parameter value"
                                         data-bind="event: { keyup: $component.updateRequestSummary }, textInput: parameter.value">
-                                    <span class="invalid-feedback" data-bind="validationMessage: parameter.value"></span>
+                                    <span class="invalid-feedback"
+                                        data-bind="validationMessage: parameter.value"></span>
                                 </div>
                                 <!-- /ko -->
                             </div>
@@ -143,7 +144,6 @@
                                     <input type="text" autocomplete="off" class="form-control form-control-sm"
                                         placeholder="value" spellcheck="false" aria-label="Parameter value"
                                         data-bind="textInput: parameter.value, attr:{ 'aria-required': parameter.required }">
-                                    <span class="invalid-feedback" data-bind="validationMessage: parameter.value"></span>
                                     <!-- /ko -->
                                     <!-- ko if: parameter.secret-->
                                     <input autocomplete="off" class="form-control form-control-sm" placeholder="value"
@@ -155,6 +155,8 @@
                                             data-bind="class: parameter.revealed() ? 'icon-emb icon-emb-eye-fill' :'icon-emb icon-emb-eye'"></i>
                                     </button>
                                     <!-- /ko -->
+                                    <span class="invalid-feedback"
+                                        data-bind="validationMessage: parameter.value"></span>
                                     <!-- /ko -->
                                 </div>
                             </div>
@@ -270,21 +272,25 @@
                     <div class="col-7 flex">
                         <!-- ko if: request.readonlyBodyFormat -->
                         <div class="form-check form-check-inline">
-                            <input class="form-check-input" type="radio" name="bodyFormat" id="bodyFormatForm" value="form"
+                            <input class="form-check-input" type="radio" name="bodyFormat" id="bodyFormatForm"
+                                value="form"
                                 data-bind="checked: request.bodyFormat, attr: { disabled: request.readonlyBodyFormat}">
                             <label class="form-check-label" for="bodyFormatRaw">Form-data</label>
                         </div>
                         <!-- /ko -->
                         <div class="form-check form-check-inline">
-                            <input class="form-check-input" type="radio" name="bodyFormat" id="bodyFormatRaw" value="raw"
+                            <input class="form-check-input" type="radio" name="bodyFormat" id="bodyFormatRaw"
+                                value="raw"
                                 data-bind="checked: request.bodyFormat, attr: { disabled: request.readonlyBodyFormat}">
-                            <label class="form-check-label" for="bodyFormatRaw" aria-label="Request body format Raw">Raw</label>
+                            <label class="form-check-label" for="bodyFormatRaw"
+                                aria-label="Request body format Raw">Raw</label>
                         </div>
                         <div class="form-check form-check-inline">
                             <input class="form-check-input" type="radio" name="bodyFormat" id="bodyFormatBinary"
                                 value="binary"
                                 data-bind="checked: request.bodyFormat, attr: { disabled: request.readonlyBodyFormat}">
-                            <label class="form-check-label" for="bodyFormatBinary" aria-label="Request body format Binary">Binary</label>
+                            <label class="form-check-label" for="bodyFormatBinary"
+                                aria-label="Request body format Binary">Binary</label>
                         </div>
                     </div>
                 </div>
@@ -323,7 +329,8 @@
                     <!-- /ko -->
                     <!-- ko if: request.bodyFormat() === 'binary' -->
                     <file-input params="{ onSelect: $component.onFileSelect }" class="form-control"
-                        aria-label="Upload file" data-bind="css: { 'is-invalid': !request.binary.isValid() }"></file-input>
+                        aria-label="Upload file"
+                        data-bind="css: { 'is-invalid': !request.binary.isValid() }"></file-input>
                     <span class="invalid-feedback" data-bind="validationMessage: request.binary"></span>
                     <!-- /ko -->
                 </div>
@@ -337,8 +344,8 @@
                     <div class="form-group">
                         <!-- ko if: item.bodyFormat() === 'string' -->
                         <div class="input-group">
-                            <input type="text" autocomplete="off" class="form-control form-control-sm" spellcheck="false"
-                                data-bind="textInput: item.body">
+                            <input type="text" autocomplete="off" class="form-control form-control-sm"
+                                spellcheck="false" data-bind="textInput: item.body">
                         </div>
                         <!-- /ko -->
                         <!-- ko if: item.bodyFormat() === 'raw' -->
@@ -346,8 +353,9 @@
                             data-bind="textInput: item.body"></textarea>
                         <!-- /ko -->
                         <!-- ko if: item.bodyFormat() === 'binary' -->
-                        <file-input params="{ containerItem: item, onSelect: $component.onFileSelect }" class="form-control"
-                            aria-label="Request body" data-bind="css: { 'is-invalid': !item.binary.isValid() }">
+                        <file-input params="{ containerItem: item, onSelect: $component.onFileSelect }"
+                            class="form-control" aria-label="Request body"
+                            data-bind="css: { 'is-invalid': !item.binary.isValid() }">
                         </file-input>
                         <span class="invalid-feedback" data-bind="validationMessage: item.binary"></span>
                         <!-- /ko -->
@@ -355,8 +363,9 @@
                 </div>
                 <!-- /ko -->
                 <div class="col-1">
-                    <a href="#" role="button" data-bind="click: $component.removeBody" class="btn-centered-vert btn-inline"
-                        aria-label="Remove body"><i class="icon-emb icon-emb-trash"></i></a>
+                    <a href="#" role="button" data-bind="click: $component.removeBody"
+                        class="btn-centered-vert btn-inline" aria-label="Remove body"><i
+                            class="icon-emb icon-emb-trash"></i></a>
                 </div>
                 <!-- /ko -->
             </details>
@@ -436,7 +445,8 @@
                             <i class="icon-emb icon-emb-eye"></i> Show
                             <!-- /ko -->
                         </button>
-                        <button class="code-snippet-command" data-bind="copyToClipboard: $component.getPlainTextCodeSample"
+                        <button class="code-snippet-command"
+                            data-bind="copyToClipboard: $component.getPlainTextCodeSample"
                             aria-label="Copy to clipboard">
                             <i class="icon-emb icon-emb-duplicate"></i> Copy
                         </button>
@@ -451,8 +461,8 @@
                 <h3>Payload</h3>
                 <div class="flex justify-content-end">
                     <div class="form-check form-check-inline">
-                        <input class="form-check-input" type="radio" name="wsDataFormat" id="wsDataFormatRaw" value="raw"
-                            data-bind="checked: wsDataFormat">
+                        <input class="form-check-input" type="radio" name="wsDataFormat" id="wsDataFormatRaw"
+                            value="raw" data-bind="checked: wsDataFormat">
                         <label class="form-check-label" for="wsDataFormatRaw">Raw</label>
                     </div>
                     <div class="form-check form-check-inline">
@@ -469,7 +479,8 @@
                     <!-- ko if: wsDataFormat() === 'binary' -->
                     <file-input params="{ onSelect: $component.onFileSelect }" class="form-control" aria-label="Payload"
                         data-bind="css: { 'is-invalid': !consoleOperation().request.binary.isValid() }"></file-input>
-                    <span class="invalid-feedback" data-bind="validationMessage: consoleOperation().request.binary"></span>
+                    <span class="invalid-feedback"
+                        data-bind="validationMessage: consoleOperation().request.binary"></span>
                     <!-- /ko -->
                 </div>
 
@@ -487,8 +498,8 @@
                 <!-- ko if: wsLogItems().length > 0 -->
                 <div class="code-snippet">
                     <div class="code-snippet-heading">
-                        <button class="code-snippet-command" data-bind="click: $component.clearLogs, disabled: wsSending"
-                            aria-label="Clear logs">
+                        <button class="code-snippet-command"
+                            data-bind="click: $component.clearLogs, disabled: wsSending" aria-label="Clear logs">
                             <i class="icon-emb icon-emb-trash"></i> Clear
                         </button>
                     </div>
@@ -531,11 +542,10 @@
         </div>
         <!-- /ko -->
 
-        <!-- ko if: $component.selectedLanguage() === 'http' -->
         <!-- ko if: requestError -->
-        <div class="panel panel-dark" data-bind="scrollintoview: {}">
+        <div class="alert alert-danger" data-bind="scrollintoview: {}">
             <p>Unable to complete the request</p>
-            <p class="text-muted" data-bind="html: requestError"></p>
+            <p data-bind="html: requestError"></p>
         </div>
         <!-- /ko -->
 
@@ -549,7 +559,6 @@
 
 <span data-bind="text: responseBody"></span></pre>
         </div>
-        <!--/ko-->
         <!--/ko-->
     </div>
 

--- a/src/components/operations/operation-details/ko/runtime/operation-console.ts
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.ts
@@ -347,6 +347,7 @@ export class OperationConsole {
     public async updateRequestSummary(): Promise<void> {
         const template = templates[this.selectedLanguage()];
         const codeSample = await TemplatingService.render(template, { console: ko.toJS(this.consoleOperation), showSecrets: this.secretsRevealed });
+        this.requestError(null);
 
         this.codeSample(codeSample);
     }
@@ -368,6 +369,7 @@ export class OperationConsole {
 
         if (clientErrors.length > 0) {
             validationGroup.showAllMessages();
+            this.requestError("Required fields are missing or incomplete. Please review the request and ensure all required information is provided. Look for highlighted areas with error indicators.");
             return;
         }
 
@@ -581,6 +583,7 @@ export class OperationConsole {
         const clientErrors = validationGroup();
 
         if (clientErrors.length > 0) {
+            this.requestError("Required fields are missing or incomplete. Please review the request and ensure all required information is provided. Look for highlighted areas with error indicators.");
             validationGroup.showAllMessages();
             return;
         }


### PR DESCRIPTION
This PR introduces some improvements for the Subscription Key flows in the test console:
1. If the subscription key is required, the header is always present in the "headers" section, and marked as required:
![image](https://github.com/Azure/api-management-developer-portal/assets/92857141/523ec207-ba3e-4ba1-927e-0ebe6b9f345b)

2. The "Subscription key" from Authorization section is masked out by default an it can be un-masked:
![subscriptionkeyauth](https://github.com/Azure/api-management-developer-portal/assets/92857141/fd319ad7-5065-455d-a23b-0f8dbcea2940)

3. If the user tries to send the request without any value completed for the subscription key header, the request will not be sent and an error will be shown: (related issue #2202)
![image](https://github.com/Azure/api-management-developer-portal/assets/92857141/a49e5cfa-637f-4064-b156-c6846bf260fa)

Similar behavior for GraphQL and WebSocket and subscription key parameter.
