### PR TITLE
Fixed adding parameters for GraphQL APIs that already have parameters

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/graphql-console.ts
+++ b/src/components/operations/operation-details/ko/runtime/graphql-console.ts
@@ -635,7 +635,7 @@ export class GraphqlConsole {
             versionPath = `/${api.apiVersion}`;
         }
 
-        let requestUrl = "";
+        let requestUrl = `${api.path}${versionPath}`;
         const parameters = this.queryParameters();
 
         parameters.forEach(parameter => {
@@ -659,7 +659,7 @@ export class GraphqlConsole {
             requestUrl = this.addParam(requestUrl, api.apiVersionSet.versionQueryName, api.apiVersion);
         }
 
-        return `${api.path}${versionPath}${requestUrl}`;
+        return requestUrl;
     }
 
     private addParam(uri: string, name: string, value: string): string {


### PR DESCRIPTION
## Problem
Adding parameters from the test console for GraphQL APIs that already have a parameter in the URL results in miss-formatted URLs with double '?'
This problem occurs because our code checks for the '?' character only within the portion of the URL we create when adding query parameters.

## Solution
Check for '?' throughout the entire URL, ensuring that we do not duplicate it.

Closes #2281 