### PR TITLE
Increase min version for management api

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -293,7 +293,7 @@ export enum GrantTypes {
     password = "password"
 }
 
-export const managementApiVersion = "2021-04-01-preview";
+export const managementApiVersion = "2021-08-01";
 
 /**
  * Header name to track developer portal type.


### PR DESCRIPTION
The version which is currently used will be deprecated soon.
Having that the PR increases to the previous GA, which is nearest api version which is not deprecated