### PR TITLE
Fixed Product APIs registration

### DIFF
--- a/src/components/products/product-apis/ko/productApisEditor.module.ts
+++ b/src/components/products/product-apis/ko/productApisEditor.module.ts
@@ -27,7 +27,7 @@ export class ProductApisEditorModule implements IInjectorModule {
         });
 
         widgetService.registerWidgetEditor("product-apis", {
-            displayName: "Operation: Details",
+            displayName: "Product: APIs",
             category: "APIs",
             iconClass: "widget-icon widget-icon-api-management",
             componentBinder: KnockoutComponentBinder,
@@ -44,7 +44,7 @@ export class ProductApisEditorModule implements IInjectorModule {
         });
 
         widgetService.registerWidgetEditor("product-apis-tiles", {
-            displayName: "Operation: Details (tiles)",
+            displayName: "Product: APIs (tiles)",
             category: "APIs",
             iconClass: "widget-icon widget-icon-api-management",
             componentBinder: KnockoutComponentBinder,


### PR DESCRIPTION
## Problem
The widget "Product: APIs" is registered at runtime with the same name as "Operation: Details", resulting in having two widgets with the same name in the list of widgets. Only one of them is displayed, Product: APIs under the name of Operation: Details. This prevents the user from adding a new "Operation: Detail" widget.

## Solution
Register the widget "Product: APIs" (and "Product: APIs (tiles)) under the correct name.