### PR TITLE
Fixed: UTF-8 characters that have more than 1 byte get truncated by migrate scripts

### DIFF
--- a/scripts.v2/utils.js
+++ b/scripts.v2/utils.js
@@ -83,13 +83,13 @@ async function request(method, url, accessToken, body) {
 
     return new Promise((resolve, reject) => {
         const req = https.request(url, options, (resp) => {
-            let data = '';
-
+            let chunks = [];
             resp.on('data', (chunk) => {
-                data += chunk;
+                chunks.push(chunk);
             });
 
             resp.on('end', () => {
+                let data = Buffer.concat(chunks).toString('utf8');
                 switch (resp.statusCode) {
                     case 200:
                     case 201:

--- a/scripts.v3/utils.js
+++ b/scripts.v3/utils.js
@@ -65,13 +65,13 @@ class HttpClient {
 
         return new Promise((resolve, reject) => {
             const req = https.request(requestUrl.toString(), options, (resp) => {
-                let data = '';
-
+                let chunks = [];
                 resp.on('data', (chunk) => {
-                    data += chunk;
+                    chunks.push(chunk);
                 });
 
                 resp.on('end', () => {
+                    let data = Buffer.concat(chunks).toString('utf8');
                     switch (resp.statusCode) {
                         case 200:
                         case 201:


### PR DESCRIPTION
### Problem
During the executing of the capture scripts, when we send the requests, we receive the response as chunks of data, that are joined into a string.
UTF-8 characters that are represented on more than 1 byte can get split in two different chunks.
Because we convert the chunk to string immediately after receiving it, this may result in unknown characters (as the whole representation is not present in the chunk).

### Solution
Keep the chunks in a Buffer Array and only convert it to a string at the end, when we have the entire data.