### PR TITLE
Fixed error when changing OAuth flow

### DIFF
--- a/src/services/oauthService.ts
+++ b/src/services/oauthService.ts
@@ -120,41 +120,24 @@ export class OAuthService {
             query: query
         });
 
-        return new Promise((resolve, reject) => {
-            const receiveMessage = async (event: MessageEvent): Promise<void> => {
-                try {
-                    const tokenHash = event.data["uri"];
+        const listener = async (event: MessageEvent): Promise<string> => {
+            const tokenHash = event.data["uri"];
 
-                    if (!tokenHash) {
-                        return;
-                    }
-
-                    const tokenInfo = await oauthClient.token.getToken(redirectUri + tokenHash);
-
-                    if (tokenInfo.accessToken) {
-                        resolve(`${Utils.toTitleCase(tokenInfo.tokenType)} ${tokenInfo.accessToken}`);
-                    }
-                    else if (tokenInfo.data?.id_token) {
-                        resolve(`Bearer ${tokenInfo.data.id_token}`);
-                    }
-                }
-                catch (error) {
-                    reject(error);
-                }
-                finally {
-                    window.removeEventListener("message", receiveMessage, false);
-                }
-            };
-
-            try {
-                const popup = window.open(oauthClient.token.getUri(), "_blank", "width=400,height=500");
-                window.addEventListener("message", receiveMessage, false);
-                this.ensurePopupIsClosed(popup, receiveMessage);
+            if (!tokenHash) {
+                return;
             }
-            catch (error) {
-                reject(error);
+
+            const tokenInfo = await oauthClient.token.getToken(redirectUri + tokenHash);
+
+            if (tokenInfo.accessToken) {
+                return `${Utils.toTitleCase(tokenInfo.tokenType)} ${tokenInfo.accessToken}`;
             }
-        });
+            else if (tokenInfo.data?.id_token) {
+                return `Bearer ${tokenInfo.data.id_token}`;
+            }
+        };
+
+        return this.openAuthPopup(oauthClient.token.getUri(), listener);
     }
 
     /**
@@ -178,35 +161,18 @@ export class OAuthService {
             query: query
         });
 
-        return new Promise<string>((resolve, reject) => {
-            const receiveMessage = async (event: MessageEvent): Promise<void> => {
-                try {
-                    if (!event.data["accessToken"]) {
-                        alert("Unable to authenticate due to internal error.");
-                        return;
-                    }
-
-                    const accessToken = event.data["accessToken"];
-                    const accessTokenType = event.data["accessTokenType"];
-                    resolve(`${Utils.toTitleCase(accessTokenType)} ${accessToken}`);
-                }
-                catch (error) {
-                    reject(error);
-                }
-                finally {
-                    window.removeEventListener("message", receiveMessage, false);
-                }
-            };
-
-            try {
-                const popup = window.open(oauthClient.code.getUri(), "_blank", "width=400,height=500");
-                window.addEventListener("message", receiveMessage, false);
-                this.ensurePopupIsClosed(popup, receiveMessage);
+        const listener = async (event: MessageEvent): Promise<string> => {
+            if (!event.data["accessToken"]) {
+                alert("Unable to authenticate due to internal error.");
+                return;
             }
-            catch (error) {
-                reject(error);
-            }
-        });
+
+            const accessToken = event.data["accessToken"];
+            const accessTokenType = event.data["accessTokenType"];
+            return `${Utils.toTitleCase(accessTokenType)} ${accessToken}`;
+        }
+
+        return this.openAuthPopup(oauthClient.code.getUri(), listener);
     }
 
     public async authenticateCodeWithPkce(backendUrl: string, authorizationServer: AuthorizationServer): Promise<string> {
@@ -229,60 +195,43 @@ export class OAuthService {
             scope: authorizationServer.scopes.join(" ")
         });
 
-        return new Promise((resolve, reject) => {
-            const receiveMessage = async (event: MessageEvent): Promise<void> => {
-                try {
-                    const authorizationCode = event.data["code"];
+        const listener = async (event: MessageEvent): Promise<string> => {
+            const authorizationCode = event.data["code"];
 
-                    if (!authorizationCode) {
-                        alert("Unable to authenticate due to internal error.");
-                        return;
-                    }
-
-                    const body = new URLSearchParams({
-                        client_id: authorizationServer.clientId,
-                        code_verifier: sessionStorage.getItem("code_verifier"),
-                        grant_type: GrantTypes.authorizationCode,
-                        redirect_uri: redirectUri,
-                        code: authorizationCode
-                    });
-
-                    const response = await this.httpClient.send<OAuthTokenResponse>({
-                        url: authorizationServer.tokenEndpoint,
-                        method: HttpMethod.post,
-                        headers: [{ name: KnownHttpHeaders.ContentType, value: KnownMimeTypes.UrlEncodedForm }],
-                        body: body.toString()
-                    });
-
-                    if (response.statusCode === 400) {
-                        const error = response.toText();
-                        alert(error);
-                        return;
-                    }
-
-                    const tokenResponse = response.toObject();
-                    const accessToken = tokenResponse.access_token;
-                    const accessTokenType = tokenResponse.token_type;
-
-                    resolve(`${Utils.toTitleCase(accessTokenType)} ${accessToken}`);
-                }
-                catch (error) {
-                    reject(error);
-                }
-                finally {
-                    window.removeEventListener("message", receiveMessage, false);
-                }
-            };
-
-            try {
-                const popup = window.open(`${authorizationServer.authorizationEndpoint}?${args}`, "_blank", "width=400,height=500");
-                window.addEventListener("message", receiveMessage, false);
-                this.ensurePopupIsClosed(popup, receiveMessage);
+            if (!authorizationCode) {
+                alert("Unable to authenticate due to internal error.");
+                return;
             }
-            catch (error) {
-                reject(error);
+
+            const body = new URLSearchParams({
+                client_id: authorizationServer.clientId,
+                code_verifier: sessionStorage.getItem("code_verifier"),
+                grant_type: GrantTypes.authorizationCode,
+                redirect_uri: redirectUri,
+                code: authorizationCode
+            });
+
+            const response = await this.httpClient.send<OAuthTokenResponse>({
+                url: authorizationServer.tokenEndpoint,
+                method: HttpMethod.post,
+                headers: [{ name: KnownHttpHeaders.ContentType, value: KnownMimeTypes.UrlEncodedForm }],
+                body: body.toString()
+            });
+
+            if (response.statusCode === 400) {
+                const error = response.toText();
+                alert(error);
+                return;
             }
-        });
+
+            const tokenResponse = response.toObject();
+            const accessToken = tokenResponse.access_token;
+            const accessTokenType = tokenResponse.token_type;
+
+            return `${Utils.toTitleCase(accessTokenType)} ${accessToken}`;
+        };
+
+        return this.openAuthPopup(`${authorizationServer.authorizationEndpoint}?${args}`, listener);
     }
 
     /**
@@ -321,34 +270,17 @@ export class OAuthService {
             uri += `?scopes=${encodeURIComponent(scopesString)}`;
         }
 
-        return new Promise<string>((resolve, reject) => {
-            const receiveMessage = async (event: MessageEvent): Promise<void> => {
-                try {
-                    if (!event.data["accessToken"]) {
-                        return;
-                    }
-
-                    const accessToken = event.data["accessToken"];
-                    const accessTokenType = event.data["accessTokenType"];
-                    resolve(`${Utils.toTitleCase(accessTokenType)} ${accessToken}`);
-                }
-                catch (error) {
-                    reject(error);
-                }
-                finally {
-                    window.removeEventListener("message", receiveMessage, false);
-                }
+        const listener = async (event: MessageEvent): Promise<string> => {
+            if (!event.data["accessToken"]) {
+                return;
             }
 
-            try {
-                const popup = window.open(uri, "_blank", "width=400,height=500");
-                window.addEventListener("message", receiveMessage, false);
-                this.ensurePopupIsClosed(popup, receiveMessage);
-            }
-            catch (error) {
-                reject(error);
-            }
-        });
+            const accessToken = event.data["accessToken"];
+            const accessTokenType = event.data["accessTokenType"];
+            return `${Utils.toTitleCase(accessTokenType)} ${accessToken}`;
+        };
+
+        return this.openAuthPopup(uri, listener);
     }
 
     public async authenticatePassword(username: string, password: string, authorizationServer: AuthorizationServer): Promise<string> {
@@ -387,4 +319,30 @@ export class OAuthService {
         }, 1000);
     }
 
+    private openAuthPopup(uri: string, listener: (event: MessageEvent<any>) => any): Promise<string> {
+        return new Promise<string>((resolve, reject) => {
+            try {
+                const popup = window.open(uri, "_blank", "width=400,height=500");
+
+                const receiveMessage = async (event: MessageEvent<any>) => {
+                    try {
+                        const result = await listener(event);
+                        resolve(result);
+                    }
+                    catch (error) {
+                        reject(error);
+                    }
+                    finally {
+                        window.removeEventListener("message", listener, false);
+                    }
+                };
+
+                window.addEventListener("message", receiveMessage, false);
+                this.ensurePopupIsClosed(popup, receiveMessage);
+            }
+            catch (error) {
+                reject(error);
+            }
+        });
+    }
 }

--- a/src/services/oauthService.ts
+++ b/src/services/oauthService.ts
@@ -147,8 +147,9 @@ export class OAuthService {
             };
 
             try {
-                window.open(oauthClient.token.getUri(), "_blank", "width=400,height=500");
+                const popup = window.open(oauthClient.token.getUri(), "_blank", "width=400,height=500");
                 window.addEventListener("message", receiveMessage, false);
+                this.ensurePopupIsClosed(popup, receiveMessage);
             }
             catch (error) {
                 reject(error);
@@ -198,8 +199,9 @@ export class OAuthService {
             };
 
             try {
-                window.open(oauthClient.code.getUri(), "_blank", "width=400,height=500");
+                const popup = window.open(oauthClient.code.getUri(), "_blank", "width=400,height=500");
                 window.addEventListener("message", receiveMessage, false);
+                this.ensurePopupIsClosed(popup, receiveMessage);
             }
             catch (error) {
                 reject(error);
@@ -273,8 +275,9 @@ export class OAuthService {
             };
 
             try {
-                window.open(`${authorizationServer.authorizationEndpoint}?${args}`, "_blank", "width=400,height=500");
+                const popup = window.open(`${authorizationServer.authorizationEndpoint}?${args}`, "_blank", "width=400,height=500");
                 window.addEventListener("message", receiveMessage, false);
+                this.ensurePopupIsClosed(popup, receiveMessage);
             }
             catch (error) {
                 reject(error);
@@ -338,8 +341,9 @@ export class OAuthService {
             }
 
             try {
-                window.open(uri, "_blank", "width=400,height=500");
+                const popup = window.open(uri, "_blank", "width=400,height=500");
                 window.addEventListener("message", receiveMessage, false);
+                this.ensurePopupIsClosed(popup, receiveMessage);
             }
             catch (error) {
                 reject(error);
@@ -373,4 +377,14 @@ export class OAuthService {
 
         throw new Error(`Unable to authenticate. Response: ${response.toText()}`);
     }
+
+    private ensurePopupIsClosed(popup: Window, receiveMessage: (event: MessageEvent<any>) => any): void {
+        const checkPopup = setInterval(() => {
+            if (!popup || popup.closed) {
+                clearInterval(checkPopup);
+                window.removeEventListener("message", receiveMessage, false);
+            }
+        }, 1000);
+    }
+
 }

--- a/src/services/oauthService.ts
+++ b/src/services/oauthService.ts
@@ -121,10 +121,8 @@ export class OAuthService {
         });
 
         return new Promise((resolve, reject) => {
-            try {
-                window.open(oauthClient.token.getUri(), "_blank", "width=400,height=500");
-
-                const receiveMessage = async (event: MessageEvent) => {
+            const receiveMessage = async (event: MessageEvent): Promise<void> => {
+                try {
                     const tokenHash = event.data["uri"];
 
                     if (!tokenHash) {
@@ -139,8 +137,17 @@ export class OAuthService {
                     else if (tokenInfo.data?.id_token) {
                         resolve(`Bearer ${tokenInfo.data.id_token}`);
                     }
-                };
+                }
+                catch (error) {
+                    reject(error);
+                }
+                finally {
+                    window.removeEventListener("message", receiveMessage, false);
+                }
+            };
 
+            try {
+                window.open(oauthClient.token.getUri(), "_blank", "width=400,height=500");
                 window.addEventListener("message", receiveMessage, false);
             }
             catch (error) {
@@ -171,10 +178,8 @@ export class OAuthService {
         });
 
         return new Promise<string>((resolve, reject) => {
-            try {
-                window.open(oauthClient.code.getUri(), "_blank", "width=400,height=500");
-
-                const receiveMessage = async (event: MessageEvent): Promise<void> => {
+            const receiveMessage = async (event: MessageEvent): Promise<void> => {
+                try {
                     if (!event.data["accessToken"]) {
                         alert("Unable to authenticate due to internal error.");
                         return;
@@ -183,9 +188,17 @@ export class OAuthService {
                     const accessToken = event.data["accessToken"];
                     const accessTokenType = event.data["accessTokenType"];
                     resolve(`${Utils.toTitleCase(accessTokenType)} ${accessToken}`);
+                }
+                catch (error) {
+                    reject(error);
+                }
+                finally {
                     window.removeEventListener("message", receiveMessage, false);
-                };
+                }
+            };
 
+            try {
+                window.open(oauthClient.code.getUri(), "_blank", "width=400,height=500");
                 window.addEventListener("message", receiveMessage, false);
             }
             catch (error) {
@@ -215,10 +228,8 @@ export class OAuthService {
         });
 
         return new Promise((resolve, reject) => {
-            try {
-                window.open(`${authorizationServer.authorizationEndpoint}?${args}`, "_blank", "width=400,height=500");
-
-                const receiveMessage = async (event: MessageEvent): Promise<void> => {
+            const receiveMessage = async (event: MessageEvent): Promise<void> => {
+                try {
                     const authorizationCode = event.data["code"];
 
                     if (!authorizationCode) {
@@ -252,9 +263,17 @@ export class OAuthService {
                     const accessTokenType = tokenResponse.token_type;
 
                     resolve(`${Utils.toTitleCase(accessTokenType)} ${accessToken}`);
+                }
+                catch (error) {
+                    reject(error);
+                }
+                finally {
                     window.removeEventListener("message", receiveMessage, false);
-                };
+                }
+            };
 
+            try {
+                window.open(`${authorizationServer.authorizationEndpoint}?${args}`, "_blank", "width=400,height=500");
                 window.addEventListener("message", receiveMessage, false);
             }
             catch (error) {
@@ -300,10 +319,8 @@ export class OAuthService {
         }
 
         return new Promise<string>((resolve, reject) => {
-            try {
-                window.open(uri, "_blank", "width=400,height=500");
-
-                const receiveMessage = async (event: MessageEvent) => {
+            const receiveMessage = async (event: MessageEvent): Promise<void> => {
+                try {
                     if (!event.data["accessToken"]) {
                         return;
                     }
@@ -311,8 +328,17 @@ export class OAuthService {
                     const accessToken = event.data["accessToken"];
                     const accessTokenType = event.data["accessTokenType"];
                     resolve(`${Utils.toTitleCase(accessTokenType)} ${accessToken}`);
-                };
+                }
+                catch (error) {
+                    reject(error);
+                }
+                finally {
+                    window.removeEventListener("message", receiveMessage, false);
+                }
+            }
 
+            try {
+                window.open(uri, "_blank", "width=400,height=500");
                 window.addEventListener("message", receiveMessage, false);
             }
             catch (error) {

--- a/src/services/oauthService.ts
+++ b/src/services/oauthService.ts
@@ -183,6 +183,7 @@ export class OAuthService {
                     const accessToken = event.data["accessToken"];
                     const accessTokenType = event.data["accessTokenType"];
                     resolve(`${Utils.toTitleCase(accessTokenType)} ${accessToken}`);
+                    window.removeEventListener("message", receiveMessage, false);
                 };
 
                 window.addEventListener("message", receiveMessage, false);
@@ -251,6 +252,7 @@ export class OAuthService {
                     const accessTokenType = tokenResponse.token_type;
 
                     resolve(`${Utils.toTitleCase(accessTokenType)} ${accessToken}`);
+                    window.removeEventListener("message", receiveMessage, false);
                 };
 
                 window.addEventListener("message", receiveMessage, false);


### PR DESCRIPTION
### Problem
In the test console, after a successful authentication with "authorization_code" flow, if the user tries to authenticate with "authorization_Code (PKCE)", the error "Unable to authenticate due to internal error." is thrown.
![image](https://github.com/Azure/api-management-developer-portal/assets/92857141/70e67b69-dad4-4981-be1a-acf4f39b8ab6)

### Solution
Remove the event listener after the authentication with either of the flows is completed, so they don't overlap.
