### PR TITLE
Fixed: custom HTML widget not rendering on published portals

### DIFF
--- a/src/components/custom-html/customHtml.publish.module.ts
+++ b/src/components/custom-html/customHtml.publish.module.ts
@@ -2,7 +2,7 @@ import { IInjectorModule, IInjector } from "@paperbits/common/injection";
 import { CustomHtmlViewModel } from "./ko/customHtmlViewModel";
 import { CustomHtmlModelBinder } from "./customHtmlModelBinder";
 import { CustomHtmlViewModelBinder } from "./ko/customHtmlViewModelBinder";
-import { widgetName } from "../custom-widget";
+import { widgetName } from "./constants";
 import { IWidgetService } from "@paperbits/common/widgets";
 import { CustomHtmlModel } from "./customHtmlModel";
 import { KnockoutComponentBinder } from "@paperbits/core/ko";


### PR DESCRIPTION
### Problem
After updating to the new model registration, the custom HTML widget was registered with the wrong name for publishing. This results in the widget not being rendered for published portals.

### Solution
Register custom HTML widget with the correct name.

Closes #2369 