### PR TITLE
Fixed: error when loading subscriptions without user signed in

### DIFF
--- a/src/components/users/subscriptions/ko/runtime/subscriptions.ts
+++ b/src/components/users/subscriptions/ko/runtime/subscriptions.ts
@@ -54,6 +54,10 @@ export class Subscriptions {
 
     private async loadUser(): Promise<void> {
         this.userId = await this.usersService.ensureSignedIn();
+        if(!this.userId){
+            return;
+        }
+        
         await this.loadSubscriptions();
     }
 


### PR DESCRIPTION
### Problem
When initializing the "Subscriptions" widget, we check if the user is signed in and if not, we redirect them to the sign in page. However, the flow for loading subscriptions continues, even if there is no userId set, resulting in the error `Unable to load subscriptions. Error: Parameter "userId" not specified.`

### Solution
If, after checking whether the user is signed in or not, we do not receive any userId in return, stop the execution of the initialization of the widget.