### PR TITLE
Fixed: error when loading operations grouped by tags without apiId

### DIFF
--- a/src/components/operations/operation-list/ko/runtime/operation-list.ts
+++ b/src/components/operations/operation-list/ko/runtime/operation-list.ts
@@ -142,7 +142,6 @@ export class OperationList {
     }
 
     public async loadOperations(): Promise<void> {
-
         if (this.groupByTag()) {
             this.operationGroups([]);
             this.searchRequest = { pattern: this.pattern(), tags: this.tags(), grouping: "tag" };
@@ -194,6 +193,11 @@ export class OperationList {
     }
 
     private async loadOfOperationsByTag(): Promise<void> {
+        const apiName = this.selectedApiName();
+        if (!apiName) {
+            return;
+        }
+
         this.searchRequest.skip = (this.pageNumber() - 1) * Constants.defaultPageSize;
 
         const pageOfOperationsByTag = await this.apiService.getOperationsByTags(this.selectedApiName(), this.searchRequest);
@@ -205,7 +209,6 @@ export class OperationList {
 
     private async loadPageOfOperations(): Promise<void> {
         const apiName = this.selectedApiName();
-
         if (!apiName) {
             return;
         }


### PR DESCRIPTION
### Problem
When loading the operations for the "Operation List" widget, if "Group by tag" is enabled and no apiId is specified in the query parameters, we throw the error `Unable to load operations: Error: Parameter "apiId" not specified.`

### Solution
Exit the flow for loading operations if the apiId is not specified.