### PR TITLE
Add view role dropdown for editor in Admin UI redesign

### DIFF
--- a/src/admin/rightPanel.tsx
+++ b/src/admin/rightPanel.tsx
@@ -5,6 +5,7 @@ import { EventManager } from '@paperbits/common/events';
 import { OfflineObjectStorage } from '@paperbits/common/persistence';
 import { IPageService } from '@paperbits/common/pages';
 import { ILayoutService } from '@paperbits/common/layouts';
+import { RoleModel, RoleService } from '@paperbits/common/user';
 import { Router } from '@paperbits/common/routing';
 import { Resolve } from '@paperbits/react/decorators';
 import { ContentWorkshop } from '../components/content';
@@ -23,7 +24,9 @@ interface RightPanelState {
     canRedo: boolean,
     mobileMenuIsOpened: boolean,
     dropdownIconStyles: object,
-    pageName: string
+    pageName: string,
+    roles: RoleModel[],
+    rolesOptions: IDropdownOption[]
 }
 
 const enum HostNames {
@@ -45,6 +48,9 @@ const iconStyles = { root: { color: darkTheme.callingPalette.iconWhite } };
 const undoIcon: IIconProps = { iconName: 'Undo', styles: iconStyles };
 const redoIcon: IIconProps = { iconName: 'Redo', styles: iconStyles };
 const sidePanelToggleIcon: IIconProps = { iconName: 'GlobalNavButton', styles: { root: { color: lightTheme.palette.themePrimary } } };
+
+const anonymousKey: string = 'anonymous';
+const anonymousName: string = 'Anonymous';
 
 export class RightPanel extends React.Component<{}, RightPanelState> {
     @Resolve('viewManager')
@@ -68,6 +74,9 @@ export class RightPanel extends React.Component<{}, RightPanelState> {
     @Resolve('layoutService')
     public layoutService: ILayoutService;
 
+    @Resolve('roleService')
+    public roleService: RoleService;
+
     constructor(props: any) {
         super(props);
 
@@ -80,7 +89,9 @@ export class RightPanel extends React.Component<{}, RightPanelState> {
             canRedo: false,
             mobileMenuIsOpened: false,
             dropdownIconStyles: { marginRight: '8px', color: lightTheme.palette.themePrimary },
-            pageName: ''
+            pageName: '',
+            roles: [{ key: anonymousKey, name: anonymousName }],
+            rolesOptions: [{ key: anonymousKey, text: anonymousName }]
         };
     }
 
@@ -88,6 +99,7 @@ export class RightPanel extends React.Component<{}, RightPanelState> {
         this.eventManager.addEventListener('onDataChange', this.onDataChange.bind(this));
         window.addEventListener('resize', this.checkScreenSize.bind(this));
         this.checkScreenSize();
+        this.getRoles();
     }
 
     componentDidUpdate(prevProps: Readonly<{}>, prevState: Readonly<RightPanelState>, snapshot?: any): void {
@@ -106,6 +118,22 @@ export class RightPanel extends React.Component<{}, RightPanelState> {
     componentWillUnmount() {
         this.eventManager.removeEventListener('onDataChange', this.onDataChange.bind(this));
         window.removeEventListener('resize', this.checkScreenSize.bind(this));
+    }
+
+    getRoles = async (): Promise<void> => {
+        const roles = await this.roleService.getRoles();
+
+        if (!roles) return;
+
+        const dropdownItems = [];
+        roles.forEach(page => {
+            dropdownItems.push({
+                key: page.key,
+                text: page.name
+            });
+        });
+
+        this.setState({ roles, rolesOptions: dropdownItems });
     }
 
     getPageName = async (): Promise<void> => {
@@ -181,14 +209,41 @@ export class RightPanel extends React.Component<{}, RightPanelState> {
         </Stack>
     )
 
+    renderRoleDropdownOption = (option: IDropdownOption): JSX.Element => (
+        <Stack horizontal verticalAlign="center">
+            <Icon
+                style={this.state.dropdownIconStyles}
+                iconName="People"
+                title="People"
+            />
+            <span>View as: {option.text}</span>
+        </Stack>
+    )
+
     renderTitle = (options: IDropdownOption[]): JSX.Element => {
         const option = options[0];
       
         return this.renderDropdownOption(option);
     }
 
+    renderRoleTitle = (options: IDropdownOption[]): JSX.Element => {
+        const option = options[0];
+
+        return this.renderRoleDropdownOption(option);
+    }
+
     renderDropdowns = (): JSX.Element => (
         <Stack horizontal>
+            <Dropdown
+                defaultSelectedKey={anonymousKey}
+                ariaLabel="Role view selector"
+                onRenderTitle={this.renderRoleTitle}
+                options={this.state.rolesOptions}
+                onChange={(event, option) => this.viewManager.setViewRoles([this.state.roles.find(role => role.key === option.key)])}
+                styles={dropdownStyles}
+                className="top-panel-dropdown"
+                dropdownWidth={170}
+            />
             <Dropdown
                 defaultSelectedKey="xl"
                 ariaLabel="Screen size selector"


### PR DESCRIPTION
Add view role dropdown for Admin UI redesign. 

![image](https://github.com/Azure/api-management-developer-portal/assets/7711251/81e45e56-181d-4643-8d11-cdb075b7c3ec)

# Problem
View role functionality was missing in Admin UI redesign feature. 

# Solution
Added missing functionality to be able to display anonymous or authenticated content in editor.

