### PR TITLE
Fixed subscription header always required

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/authorization.ts
+++ b/src/components/operations/operation-details/ko/runtime/authorization.ts
@@ -84,13 +84,6 @@ export class Authorization {
     @OnMounted()
     public async initialize(): Promise<void> {
         this.subscriptionKeyRequired(!!this.api().subscriptionRequired);
-        this.selectedSubscriptionKey.subscribe(this.applySubscriptionKey.bind(this));
-        this.selectedGrantType.subscribe(this.onGrantTypeChange);
-        this.selectedSubscriptionKey(null);
-        await this.setupOAuth();
-        if (this.api().subscriptionRequired) {
-            await this.loadSubscriptionKeys();
-        }
 
         if (this.subscriptionKeyRequired()) {
             if (this.api().type === TypeOfApi.webSocket || this.isGraphQL()) {
@@ -98,6 +91,14 @@ export class Authorization {
             } else {
                 this.setSubscriptionKeyHeader();
             }
+        }
+
+        this.selectedGrantType.subscribe(this.onGrantTypeChange);
+        this.selectedSubscriptionKey(null);
+        this.selectedSubscriptionKey.subscribe(this.applySubscriptionKey.bind(this));
+        await this.setupOAuth();
+        if (this.api().subscriptionRequired) {
+            await this.loadSubscriptionKeys();
         }
     }
 


### PR DESCRIPTION
### Problem
After the fix for managed portals for filling the subscription key when opening the test console, the `Ocp-Apim-Subscription-Key` is always marked as required in the test console. 

This is because, after subscribing to `this.selectedSubscriptionKey.subscribe(this.applySubscriptionKey.bind(this))`, we set the `selectedSubscriptionKey` to null. This results in `applySubscriptionKey` to be called (with null), which adds the header `Ocp-Apim-Subscription-Key` (with null) , even if the subscription key is not required.

### Solution
Subscribe to `applySubscriptionKey` only after we set the `selectedSubscriptionKey` to null.