### PR TITLE
Fixed heavily truncated description for APIs and Products

### DIFF
--- a/src/services/markdownService.ts
+++ b/src/services/markdownService.ts
@@ -29,7 +29,7 @@ export class MarkdownService {
             })
             .use(rehypeStringify)
             .process(markdown, (err: any, html: any) => {
-                processedHtml = truncate(html.value, length, { truncateLastWord: false, keepImageTag: true });
+                processedHtml = truncate(html.value, length, { keepImageTag: true });
             });
 
         return processedHtml;


### PR DESCRIPTION
### Problem
There is some inconsistency with how the description is truncated for APIs and Products.

### Solution
Seems that `truncateLastWord` from `html-truncate` doesn't work as expected and is miscalculating where the truncation should happen. This attribute is also marked as deprecated from version 1.0.0, so we can remove it and allow the last word to be truncated.

For the same text:
- before (with `truncateLastWord: false`): 17 characters, even if we set it to 250 in the binding
![image](https://github.com/Azure/api-management-developer-portal/assets/92857141/46e14a98-f2b7-43c6-8718-8241c2e39800)

- after: 250 characters (as set in the binding)
![image](https://github.com/Azure/api-management-developer-portal/assets/92857141/1009d332-41d4-44ec-9636-fbf85ed54ea5)

Closes #2260 , #2259 