### PR TITLE
GitHub CI permissions change

### DIFF
--- a/.github/workflows/mainCI.yml
+++ b/.github/workflows/mainCI.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
+      checks: write
       contents: read
       deployments: read
       packages: none

--- a/.github/workflows/mainCI.yml
+++ b/.github/workflows/mainCI.yml
@@ -8,6 +8,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      deployments: read
+      packages: none
+      pull-requests: write
+      security-events: write
 
     steps:
       - name: Use Node.js 16.x


### PR DESCRIPTION
Problem:
Starting February 1, 2024 the default permission for the GITHUB_TOKEN is changed from Read/Write to Read-only for all Open Source GitHub orgs. This is a breaking change to many workflows.

Solution:
Added a permission block which should resolve the breaking CI.