### PR TITLE
Use basic auth for change password

### DIFF
--- a/src/components/users/change-password/ko/runtime/change-password.ts
+++ b/src/components/users/change-password/ko/runtime/change-password.ts
@@ -138,9 +138,9 @@ export class ChangePassword {
                     userId: userId,
                     newPassword: this.newPassword()
                 };
-                await this.backendService.sendChangePassword(resetRequest);
+                await this.backendService.sendChangePassword(resetRequest, credentials);
             } else {
-                await this.usersService.changePassword(userId, this.newPassword());
+                await this.usersService.changePassword(userId, this.newPassword(), credentials);
             }
             this.isChangeConfirmed(true);
         } catch (error) {

--- a/src/services/backendService.ts
+++ b/src/services/backendService.ts
@@ -119,17 +119,11 @@ export class BackendService {
         throw new MapiError("Unhandled", "Unable to complete reset password request.");
     }
 
-    public async sendChangePassword(changePasswordRequest: ChangePasswordRequest): Promise<void> {
-        const authToken = await this.authenticator.getAccessTokenAsString();
-
-        if (!authToken) {
-            throw Error("Auth token not found");
-        }
-
+    public async sendChangePassword(changePasswordRequest: ChangePasswordRequest, token: string): Promise<void> {
         const response = await this.httpClient.send({
             url: await this.getUrl("/change-password"),
             method: HttpMethod.post,
-            headers: [{ name: KnownHttpHeaders.Authorization, value: authToken }, { name: KnownHttpHeaders.ContentType, value: KnownMimeTypes.Json }],
+            headers: [{ name: KnownHttpHeaders.Authorization, value: token }, { name: KnownHttpHeaders.ContentType, value: KnownMimeTypes.Json }],
             body: JSON.stringify(changePasswordRequest)
         });
 

--- a/src/services/usersService.ts
+++ b/src/services/usersService.ts
@@ -272,15 +272,9 @@ export class UsersService {
         await this.mapiClient.post(`/confirmations/password?appType=${Constants.AppType}`, [await this.mapiClient.getPortalHeader("createResetPasswordRequest")], payload);
     }
 
-    public async changePassword(userId: string, newPassword: string): Promise<void> {
-        const authToken = await this.authenticator.getAccessTokenAsString();
-
-        if (!authToken) {
-            throw Error("Auth token not found");
-        }
-
+    public async changePassword(userId: string, newPassword: string, token: string): Promise<void> {
         const headers = [
-            { name: KnownHttpHeaders.Authorization, value: authToken },
+            { name: KnownHttpHeaders.Authorization, value: token },
             { name: KnownHttpHeaders.IfMatch, value: "*" },
             await this.mapiClient.getPortalHeader("changePassword")
         ];


### PR DESCRIPTION
### Problem
SMAPI will only allow Basic authentication for change password requests. Developer Portal is using SharedAccessSignature token for these requests.

### Solution
Align with SMAPI and use Basic authentication for change password requests.