### PR TITLE
Upgrade dependency follow-redirects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5747,7 +5747,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.14.9",
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
             "dev": true,
             "funding": [
                 {
@@ -5755,7 +5757,6 @@
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
-            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -16078,7 +16079,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.14.9",
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
             "dev": true
         },
         "form-data": {


### PR DESCRIPTION
Solves: https://github.com/advisories/GHSA-jchw-25xp-jwwc
Severity of the alert during installation of modules: moderate
How solved: npm audit fix. 