### PR TITLE
Fixed: registered apiProducts widget correctly

### DIFF
--- a/src/components/apis/api-products/apiProductsModelBinder.ts
+++ b/src/components/apis/api-products/apiProductsModelBinder.ts
@@ -19,7 +19,7 @@ export class ApiProductsModelBinder implements IModelBinder<ApiProductsModel> {
 
     public modelToContract(model: ApiProductsModel): ApiProductsContract {
         const contract: ApiProductsContract = {
-            type: "api-products",
+            type: "apiProducts",
             itemStyleView: model.layout,
             detailsPageHyperlink: model.detailsPageHyperlink
             ? {


### PR DESCRIPTION
### Problem
The widget `API: Products` is registered with type `apiProducts`, but used in the model binder with type `api-products`. Due to this, the widget will not be recognized, when converting to contract.

### Solution
Use the type  `apiProducts` in the model binder as well.