### PR TITLE
Fixed API products widget editor registration

### DIFF
--- a/src/components/apis/api-products/ko/apiProductsEditor.module.ts
+++ b/src/components/apis/api-products/ko/apiProductsEditor.module.ts
@@ -29,7 +29,7 @@ export class ApiProductsDesignModule implements IInjectorModule {
 
         widgetService.registerWidget("api-products", apiProductsWidget);
 
-        widgetService.registerWidgetEditor("apiProducts", {
+        widgetService.registerWidgetEditor("api-products", {
             displayName: "API: Products",
             category: "APIs",
             iconClass: "widget-icon widget-icon-api-management",


### PR DESCRIPTION
**Problem:**
When changing the registration of the widget API: Products, it remained "apiProducts" in one place, resulting in runtime error.

**Solution:**
Use "api-products" for the registration everywhere.