### PR TITLE
Alt tag for images in the Media modal

### DIFF
--- a/src/admin/media/mediaModal.tsx
+++ b/src/admin/media/mediaModal.tsx
@@ -167,6 +167,7 @@ export class MediaModal extends React.Component<MediaModalProps, MediaModalState
                 </Stack>
                 <Image
                     src={thumbnailUrl ?? '/assets/images/no-preview.png'}
+                    alt={mediaItem.fileName}
                     imageFit={ImageFit.centerCover}
                     styles={{ root: { flexGrow: 1, marginTop: 10, marginBottom: 20 } }}
                     shouldStartVisible


### PR DESCRIPTION
Problem:
Images present in the "media' blade does not have alternate text defined for it.

Solution:
Added an alt attribute.