### PR TITLE
Fixed: API not loaded the first time

### DIFF
--- a/src/components/apis/details-of-api/ko/runtime/api-details.ts
+++ b/src/components/apis/details-of-api/ko/runtime/api-details.ts
@@ -44,7 +44,8 @@ export class ApiDetails {
     @OnMounted()
     public async initialize(): Promise<void> {
         const apiName = this.routeHelper.getApiName();
-
+        this.router.addRouteChangeListener(this.onRouteChange);
+        
         if (!apiName) {
             return;
         }
@@ -52,7 +53,6 @@ export class ApiDetails {
         this.selectedApiName(apiName);
         await this.loadApi(apiName);
 
-        this.router.addRouteChangeListener(this.onRouteChange);
         this.currentApiVersion.subscribe(this.onVersionChange);
         this.downloadSelected.subscribe(this.onDownloadChange);
     }


### PR DESCRIPTION
### Problem
When navigating on a page that has `API: Details` widget, the first time the user selects an API (from the widget API: list for example), it is not loaded.
This is happening due to the order of the operations in the initialization flow: if there is no API in the URL initially we `return` without subscribing to `onRouteChange()`. Hence, even if the route changes, the API: Details widget doesn't react.

### Solution
Subscribe to `onRouteChange()` even if there is no API in the URL.

Closes #2421
