### PR TITLE
aria-label attributes for fields with custom labels

### DIFF
--- a/src/admin/media/mediaModal.tsx
+++ b/src/admin/media/mediaModal.tsx
@@ -167,6 +167,7 @@ export class MediaModal extends React.Component<MediaModalProps, MediaModalState
                 </Stack>
                 <Image
                     src={thumbnailUrl ?? '/assets/images/no-preview.png'}
+                    alt={mediaItem.fileName}
                     imageFit={ImageFit.centerCover}
                     styles={{ root: { flexGrow: 1, marginTop: 10, marginBottom: 20 } }}
                     shouldStartVisible

--- a/src/admin/navigation/navigationItemModal.tsx
+++ b/src/admin/navigation/navigationItemModal.tsx
@@ -683,6 +683,7 @@ export class NavigationItemModal extends React.Component<NavigationItemModalProp
                                 info={`Assign to an existing menu item or select new menu item to create a top-level menu item.`} 
                             />
                         }
+                        ariaLabel="Assign location"
                         placeholder="Click to select a parent..."
                         options={this.state.navItemsDropdown}
                         defaultSelectedKey={this.state.parentItem !== '' ? this.state.parentItem : newItemKey}

--- a/src/admin/pages/pageDetailsModal.tsx
+++ b/src/admin/pages/pageDetailsModal.tsx
@@ -205,6 +205,7 @@ export class PageDetailsModal extends React.Component<PageDetailsModalProps, Pag
                                 info="This is how the page name will be displayed in the site menu."
                                 required
                             />}
+                        ariaLabel="Name"
                         value={this.state.page.title}
                         onChange={(event, newValue) => this.onInputChange('title', newValue, REQUIRED)}
                         errorMessage={this.state.errors['title'] ?? ''}
@@ -218,6 +219,7 @@ export class PageDetailsModal extends React.Component<PageDetailsModalProps, Pag
                                 required
                             />
                         }
+                        ariaLabel="Permalink path"
                         value={this.state.page.permalink}
                         onChange={(event, newValue) => this.onInputChange('permalink', newValue)}
                         errorMessage={this.state.errors['permalink'] ?? ''}
@@ -226,6 +228,7 @@ export class PageDetailsModal extends React.Component<PageDetailsModalProps, Pag
                     />
                     <TextField
                         onRenderLabel={() => <LabelWithInfo label="Description" info="This description helps search engines and users understand the content and purpose of this page." />}
+                        ariaLabel="Description"
                         multiline
                         autoAdjustHeight
                         value={this.state.page.description}

--- a/src/admin/pages/pageLayoutDetailsModal.tsx
+++ b/src/admin/pages/pageLayoutDetailsModal.tsx
@@ -187,6 +187,7 @@ export class PageLayoutDetailsModal extends React.Component<PageLayoutModalProps
                                 required
                             />
                         }
+                        ariaLabel="Permalink path template"
                         value={this.state.layout.permalinkTemplate}
                         onChange={(event, newValue) => this.onInputChange('permalinkTemplate', newValue)}
                         errorMessage={this.state.errors['permalinkTemplate'] ?? ''}


### PR DESCRIPTION
Problem:
There are fields in the new admin UI with custom labels. They are not accessible as they are separate texts.

Solution:
Added aria-label attribute for all fields with custom labels.