### PR TITLE
Fixed non-closing list of APIs dropdown widget

### DIFF
--- a/src/admin/media/mediaModal.tsx
+++ b/src/admin/media/mediaModal.tsx
@@ -105,6 +105,7 @@ export class MediaModal extends React.Component<MediaModalProps, MediaModalState
     }
 
     deleteMedia = async (): Promise<void> => {
+        // TODO: check if can be replaced with map loop instead. for loop is used because BE is not deleting it properly
         for (const file of this.state.selectedFiles) {
             await this.mediaService.deleteMedia(file);
         }

--- a/src/components/apis/list-of-apis/ko/runtime/api-list-dropdown.html
+++ b/src/components/apis/list-of-apis/ko/runtime/api-list-dropdown.html
@@ -79,7 +79,7 @@
             <!-- ko foreach: { data: apis, as: 'item' } -->
             <div class="menu menu-vertical" role="list">
                 <a href="#" role="listitem" class="nav-link text-truncate" data-dismiss
-                    data-bind="attr: { href: $component.getReferenceUrl(item) }, css: { 'nav-link-active': $component.selectedApiName() === item.name }">
+                    data-bind="attr: { href: $component.getReferenceUrl(item) }, css: { 'nav-link-active': $component.selectedApiName() === item.name }, activate: $component.closeDropdown">
                     <span data-bind="text: item.displayName"></span>
                     <!-- ko if: item.type === 'soap' -->
                     <span class="badge badge-soap">SOAP</span>


### PR DESCRIPTION
Problem:
A customer complains about not always closing list of APIs dropdown.

Solution:
Applied the fix I used earlier for non group by tags apis.