### PR TITLE
Fixed overlapping API dropdown

### DIFF
--- a/src/themes/website/styles/docs.scss
+++ b/src/themes/website/styles/docs.scss
@@ -176,6 +176,7 @@ api-list,
 api-list-dropdown,
 api-list-tiles {
     flex-basis: 100%;
+    max-width: 100%;
 }
 
 .line-clamp {


### PR DESCRIPTION
Problem:
If the API name is too long, it was overlapping in the API details page
![image](https://github.com/Azure/api-management-developer-portal/assets/92329687/cc7109d8-fb27-4fb0-bccc-8ef2140f8ebc)

Solution:
Added a max-width so it doesn't overlap
![image](https://github.com/Azure/api-management-developer-portal/assets/92329687/be367a91-e3b9-4ec7-b27b-ff2c29b56fd9)
