### PR TITLE
API Dropdown - navigation fix

### DIFF
--- a/src/components/apis/list-of-apis/ko/runtime/api-list-dropdown.html
+++ b/src/components/apis/list-of-apis/ko/runtime/api-list-dropdown.html
@@ -49,7 +49,7 @@
                 <div class="menu menu-vertical" role="list">
                     <!-- ko foreach: { data: group.items, as: 'item' } -->
                     <a href="#" role="listitem" class="nav-link text-truncate" data-dismiss
-                        data-bind="attr: { href: $component.getReferenceUrl(item) }, css: { 'nav-link-active': $component.selectedApiName() === item.name }, activate: $component.closeDropdown">
+                        data-bind="attr: { href: $component.getReferenceUrl(item) }, css: { 'nav-link-active': $component.selectedApiName() === item.name }, click: $component.closeDropdown">
                         <span data-bind="text: item.displayName"></span>
                         <!-- ko if: item.type === 'soap' -->
                         <span class="badge badge-soap">SOAP</span>
@@ -79,7 +79,7 @@
             <!-- ko foreach: { data: apis, as: 'item' } -->
             <div class="menu menu-vertical" role="list">
                 <a href="#" role="listitem" class="nav-link text-truncate" data-dismiss
-                    data-bind="attr: { href: $component.getReferenceUrl(item) }, css: { 'nav-link-active': $component.selectedApiName() === item.name }, activate: $component.closeDropdown">
+                    data-bind="attr: { href: $component.getReferenceUrl(item) }, css: { 'nav-link-active': $component.selectedApiName() === item.name }, click: $component.closeDropdown">
                     <span data-bind="text: item.displayName"></span>
                     <!-- ko if: item.type === 'soap' -->
                     <span class="badge badge-soap">SOAP</span>

--- a/src/components/apis/list-of-apis/ko/runtime/api-list-dropdown.ts
+++ b/src/components/apis/list-of-apis/ko/runtime/api-list-dropdown.ts
@@ -184,12 +184,14 @@ export class ApiListDropdown {
         this.groupTagsExpanded(newSet);
     }
 
-    public closeDropdown(): void {
+    public closeDropdown(): true {
         const apiDropdowns = document.getElementsByClassName("api-list-dropdown");
         for (let i = 0; i < apiDropdowns.length; i++) {
             if (apiDropdowns[i].classList.contains("show"))
                 apiDropdowns[i].classList.remove("show");
         }
+
+        return true; // return true to not-prevent the default action https://knockoutjs.com/documentation/click-binding.html#note-3-allowing-the-default-click-action
     }
 
     @OnDestroyed()


### PR DESCRIPTION
Fix for a regression found in 2.27 manual test pass:
"When trying to switch between the api’s using dropdown’s, switching doesn’t happen, only if I’m clicking on API’s section and select other API then it works."