### PR TITLE
Fixed enum values processing for console operations' query and template parameters

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/operation-console.html
+++ b/src/components/operations/operation-details/ko/runtime/operation-console.html
@@ -104,8 +104,12 @@
                         <div class="col-7">
                             <div class="form-group">
                                 <!-- ko if: parameter.options.length > 0 -->
-                                <select class="form-control" aria-label="Parameter value"
-                                    data-bind="value: parameter.value, options: parameter.options, optionsAfterRender: $component.updateRequestSummary, event:{ change: $component.updateRequestSummary }"></select>
+                                <div class="input-group has-validation">
+                                    <select class="form-control" aria-label="Parameter value"
+                                        data-bind="value: parameter.value, options: parameter.options, optionsCaption: parameter.optionsCaption, optionsAfterRender: $component.updateRequestSummary, event:{ change: $component.updateRequestSummary }"></select>
+                                    <span class="invalid-feedback"
+                                            data-bind="validationMessage: parameter.value"></span>
+                                </div>
                                 <!-- /ko -->
                                 <!-- ko if: parameter.options.length === 0 -->
                                 <div class="input-group has-validation">
@@ -135,8 +139,12 @@
                         <div class="col-7">
                             <div class="form-group">
                                 <!-- ko if: parameter.options.length > 0 -->
-                                <select class="form-control" aria-label="Parameter value"
-                                    data-bind="value: parameter.value, options: parameter.options, optionsAfterRender: $component.updateRequestSummary, event:{ change: $component.updateRequestSummary }"></select>
+                                <div class="input-group has-validation">
+                                    <select class="form-control" aria-label="Parameter value"
+                                        data-bind="value: parameter.value, options: parameter.options, optionsCaption: parameter.optionsCaption, optionsAfterRender: $component.updateRequestSummary, event:{ change: $component.updateRequestSummary }"></select>
+                                    <span class="invalid-feedback"
+                                        data-bind="validationMessage: parameter.value"></span>
+                                </div>
                                 <!-- /ko -->
                                 <div class="input-group">
                                     <!-- ko if: parameter.options.length === 0 -->

--- a/src/models/console/consoleParameter.ts
+++ b/src/models/console/consoleParameter.ts
@@ -14,6 +14,7 @@ export class ConsoleParameter {
     public canRename: boolean;
     public error: ko.Observable<string>;
     public revealed: ko.Observable<boolean>;
+    public optionsCaption: string;
 
     public toggleRevealed(): void {
         this.revealed(!this.revealed());
@@ -30,6 +31,7 @@ export class ConsoleParameter {
         this.type = "string";
         this.error = ko.observable();
         this.revealed = ko.observable(false);
+        this.optionsCaption = null;
 
         this.name.extend(<any>{ required: { message: `Name is required.` } });
 
@@ -48,6 +50,10 @@ export class ConsoleParameter {
 
         if (this.required) {
             this.value.extend(<any>{ required: { message: `Value is required.` } });
+        }
+
+        if (!contract.defaultValue) {
+            this.optionsCaption = 'Select value...';
         }
 
         this.value(contract.defaultValue);


### PR DESCRIPTION
Problem:
If you have a query parameter where you set "No default" and provide other optional values, the "Try It" sidebar defaults to the next possible value under "No default", rather than starting as blank (without a default) as expected.

Solution:
Added a placeholder when no default value is selected. Added a validation message when a parameter is not required.

Closes: #1529, #1730, #2384