### PR TITLE
browser specific iframe sandbox tokens support

### DIFF
--- a/src/components/custom-widget/ko/runtime/customWidget.ts
+++ b/src/components/custom-widget/ko/runtime/customWidget.ts
@@ -23,7 +23,7 @@ export class CustomWidget {
         this.instanceId = ko.observable();
 
         const iframe = document.getElementsByTagName("iframe")[0];
-        this.iframeSandboxAllows += " " + iframeSandboxAllowsBrowserSpecific
+        this.iframeSandboxAllows = (iframeSandboxAllows + " " + iframeSandboxAllowsBrowserSpecific)
             .split(" ")
             .filter(token=> iframe?.sandbox.supports(token))
             .join(" ");

--- a/src/components/custom-widget/ko/runtime/customWidget.ts
+++ b/src/components/custom-widget/ko/runtime/customWidget.ts
@@ -23,7 +23,7 @@ export class CustomWidget {
         this.instanceId = ko.observable();
 
         const iframe = document.getElementsByTagName("iframe")[0];
-        this.iframeSandboxAllows = (iframeSandboxAllows + " " + iframeSandboxAllowsBrowserSpecific)
+        this.iframeSandboxAllows = `${iframeSandboxAllows} ${iframeSandboxAllowsBrowserSpecific}`
             .split(" ")
             .filter(token=> iframe?.sandbox.supports(token))
             .join(" ");

--- a/src/components/custom-widget/ko/runtime/customWidget.ts
+++ b/src/components/custom-widget/ko/runtime/customWidget.ts
@@ -1,7 +1,7 @@
 import * as ko from "knockout";
 import { Component, RuntimeComponent, OnMounted, OnDestroyed, Param } from "@paperbits/common/ko/decorators";
 import { Environment } from "@azure/api-management-custom-widgets-tools";
-import { iframeAllows, iframeSandboxAllows } from "../../../../constants";
+import { iframeAllows, iframeSandboxAllows, iframeSandboxAllowsBrowserSpecific } from "../../../../constants";
 import { widgetRuntimeSelector } from "../../constants";
 import template from "./customWidget.html";
 
@@ -14,13 +14,19 @@ import template from "./customWidget.html";
 })
 export class CustomWidget {
     public readonly iframeAllows: string = iframeAllows;
-    public readonly iframeSandboxAllows: string = iframeSandboxAllows;
+    public iframeSandboxAllows: string = iframeSandboxAllows;
     private windowRef = window;
 
     constructor() {
         this.src = ko.observable();
         this.name = ko.observable();
         this.instanceId = ko.observable();
+
+        const iframe = document.getElementsByTagName("iframe")[0];
+        this.iframeSandboxAllows += " " + iframeSandboxAllowsBrowserSpecific
+            .split(" ")
+            .filter(token=> iframe?.sandbox.supports(token))
+            .join(" ");
     }
 
     @Param()

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -317,7 +317,7 @@ export const iframeAllows = "clipboard-read; clipboard-write; camera; microphone
  * List of allowed attributes for a sandboxed iframe.
  */
 export const iframeSandboxAllows = "allow-scripts allow-modals allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation allow-pointer-lock";
-export const iframeSandboxAllowsBrowserSpecific = "allow-downloads allow-presentation allow-orientation-lock"
+export const iframeSandboxAllowsBrowserSpecific = "allow-downloads allow-presentation allow-orientation-lock";
 
 /**
  * List of downloadable content types

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -316,7 +316,8 @@ export const iframeAllows = "clipboard-read; clipboard-write; camera; microphone
 /**
  * List of allowed attributes for a sandboxed iframe.
  */
-export const iframeSandboxAllows = "allow-same-origin allow-scripts allow-modals allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation allow-pointer-lock";
+export const iframeSandboxAllows = "allow-scripts allow-modals allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation allow-pointer-lock";
+export const iframeSandboxAllowsBrowserSpecific = "allow-downloads allow-presentation allow-orientation-lock"
 
 /**
  * List of downloadable content types


### PR DESCRIPTION
Remove iframe sandbox tokens which are not supported in Safari to separated string and add based on if the browser supports them. This way we won't break existing customer widgets.