### PR TITLE
Added pagination and filter support for subscriptions in the test console

### DIFF
--- a/src/components/operations/operation-details/ko/runtime/authorization.html
+++ b/src/components/operations/operation-details/ko/runtime/authorization.html
@@ -88,21 +88,52 @@
         </div>
         <div class="col-7">
             <div class="form-group">
-                <!-- ko if: $component.products() && $component.products().length > 0 -->
-                <select id="subscriptionKey" class="form-control" data-bind="value: $component.selectedSubscriptionKey">
-                    <!-- ko foreach: { data: $component.products, as: 'product' } -->
-                    <optgroup data-bind="attr: { label: product.name }">
-                        <!-- ko foreach: { data: product.subscriptionKeys, as: 'subscriptionKey' } -->
-                        <option data-bind="value: subscriptionKey.value, text: subscriptionKey.name"></option>
+                <!-- ko if: ($component.products() && $component.products().length > 0) || isSubscriptionListEmptyDueToFilter() -->
+                <div class="input-group" tabindex="0" aria-label="Subscriptions">
+                    <div class="form-control text-truncate" data-toggle="dropdown" role="button">
+                        <!-- ko if: $component.selectedSubscriptionKey() -->
+                        <span data-bind="text: $component.selectedSubscriptionKey().name"></span>
                         <!-- /ko -->
-                    </optgroup>
-                    <!-- /ko -->
-                </select>
+                    </div>
+                    <button class="input-group-addon no-border" data-toggle="dropdown"
+                        aria-label="Expand subscription list">
+                        <i class="icon-emb icon-emb-chevron-down"></i>
+                    </button>
+                    <div class="dropdown" id="subscriptions-dropdown">
+                        <!-- ko if: $component.subscriptionsLoading -->
+                        <spinner class="block" role="presentation"></spinner>
+                        <!-- /ko -->
+                        <!-- ko ifnot: $component.subscriptionsLoading -->
+                        <input type="search" class="form-control form-control-light" aria-label="Search"
+                            placeholder="Search subscriptions" data-bind="textInput: subscriptionsPattern" autofocus />
+                        <!-- ko if: isSubscriptionListEmptyDueToFilter() -->
+                        <span>No subscriptions found.</span>
+                        <!-- /ko -->
+                        <!-- ko foreach: { data: $component.products, as: 'product' } -->
+                        <span data-bind="text: product.name" style="font-weight: bold"></span>
+                        <div class="menu menu-vertical" role="list">
+                            <!-- ko foreach: { data: product.subscriptionKeys, as: 'item' } -->
+                            <a href="#" role="listitem" class="nav-link text-truncate" data-dismiss
+                                data-bind="click: $component.selectSubscription">
+                                <span data-bind="text: item.name"></span>
+                            </a>
+                            <!-- /ko -->
+                        </div>
+                        <!-- /ko -->
+                        <!-- ko if: $component.nextSubscriptionsPage() || $component.subscriptionsPageNumber() > 1 -->
+                        <pagination
+                            params="{ pageNumber: $component.subscriptionsPageNumber, nextPage: $component.nextSubscriptionsPage }">
+                        </pagination>
+                        <!-- /ko -->
+                        <!-- /ko -->
+                    </div>
+                </div>
+
                 <!-- /ko -->
-                <!-- ko if: !$component.products() || $component.products().length === 0 -->
+                <!-- ko if: (!$component.products() || $component.products().length === 0) && !isSubscriptionListEmptyDueToFilter() -->
                 <div class="input-group">
                     <input id="subscriptionKey" class="form-control" placeholder="subscription key"
-                        data-bind="textInput: $component.selectedSubscriptionKey, attr: { type: subscriptionKeyRevealed() ? 'text' : 'password' }"
+                        data-bind="textInput: $component.selectedSubscriptionKey.value, attr: { type: subscriptionKeyRevealed() ? 'text' : 'password' }"
                         aria-required="true" />
                     <button data-bind="click: toggleSubscriptionKey" class="input-group-addon">
                         <i

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -38,11 +38,9 @@ export class ProductService {
             odataFilterEntries.push(`properties/scope eq '${productId}'`)
         }
 
-        if (searchRequest) {
-            if (searchRequest.pattern) {
-                const pattern = Utils.encodeURICustomized(searchRequest.pattern, Constants.reservedCharTuplesForOData);
-                odataFilterEntries.push(`(contains(properties/displayName,'${pattern}'))`);
-            }
+        if (searchRequest.pattern) {
+            const pattern = Utils.encodeURICustomized(searchRequest.pattern, Constants.reservedCharTuplesForOData);
+            odataFilterEntries.push(`(contains(properties/displayName,'${pattern}'))`);
         }
 
         const pageOfSubscriptions = new Page<Subscription>();

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -38,7 +38,7 @@ export class ProductService {
             odataFilterEntries.push(`properties/scope eq '${productId}'`)
         }
 
-        if (searchRequest.pattern) {
+        if (searchRequest?.pattern) {
             const pattern = Utils.encodeURICustomized(searchRequest.pattern, Constants.reservedCharTuplesForOData);
             odataFilterEntries.push(`(contains(properties/displayName,'${pattern}'))`);
         }


### PR DESCRIPTION
### Problem
The subscriptions dropdown from the test console only shows he first 100 subscriptions. If a user has more, they do not have the possibility to select some of them form this dropdown.

### Solution
Added support for pagination and filtering in the subscriptions dropdown from the test console:
- the subscriptions are paginated and the user can navigate through all the pages of subscriptions
- the subscriptions can be filtered by typing in the searchbox


Below is a recording of the new behavior:
![paginated-subscriptions-with-filter](https://github.com/Azure/api-management-developer-portal/assets/92857141/b113a15f-3715-4e2c-8141-2c8e8dd95894)
