### PR TITLE
Made several Admin UI left nav items keyboard accessible

### DIFF
--- a/src/admin/custom-widgets/customWidgets.tsx
+++ b/src/admin/custom-widgets/customWidgets.tsx
@@ -81,10 +81,18 @@ export class CustomWidgets extends React.Component<CustomWidgetsProps, CustomWid
                 title="Edit"
                 style={iconStyles}
                 className="nav-item-inner"
+                tabIndex={0}
                 onClick={(event) => {
+                    this.setState({ showCustomWidgetModal: true, selectedCustomWidget: customWidget });
                     event.stopPropagation();
-                    this.setState({ showCustomWidgetModal: true, selectedCustomWidget: customWidget })}
-                }
+                }}
+                // Required for accessibility
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                        this.setState({ showCustomWidgetModal: true, selectedCustomWidget: customWidget });
+                        event.preventDefault();
+                    }
+                }}
             />
         </Stack>
     )

--- a/src/admin/pages/pages.tsx
+++ b/src/admin/pages/pages.tsx
@@ -105,7 +105,6 @@ export class Pages extends React.Component<PagesProps, PagesState> {
             horizontalAlign="space-between"
             verticalAlign="center"
             className="nav-item-outer-stack"
-            onClick={async () => await this.router.navigateTo(page.permalink)}
         >
             <Text>{page.title}</Text>
             <FontIcon
@@ -113,10 +112,18 @@ export class Pages extends React.Component<PagesProps, PagesState> {
                 title="Edit"
                 style={iconStyles}
                 className="nav-item-inner"
+                tabIndex={0}
                 onClick={(event) => {
+                    this.setState({ showPagesModal: true, selectedPage: page });
                     event.stopPropagation();
-                    this.setState({ showPagesModal: true, selectedPage: page })}
-                }
+                }}
+                // Required for accessibility
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                        this.setState({ showPagesModal: true, selectedPage: page });
+                        event.preventDefault();
+                    }
+                }}
             />
         </Stack>
     )
@@ -127,7 +134,6 @@ export class Pages extends React.Component<PagesProps, PagesState> {
             horizontalAlign="space-between"
             verticalAlign="center"
             className="nav-item-outer-stack"
-            onClick={async () => this.viewManager.setHost({ name: 'layout-host', params: { layoutKey: layout.key } })}
         >
             <Text block nowrap className="nav-item-title">{layout.title}</Text>
             <FontIcon
@@ -135,10 +141,18 @@ export class Pages extends React.Component<PagesProps, PagesState> {
                 title="Edit"
                 style={iconStyles}
                 className="nav-item-inner"
+                tabIndex={0}
                 onClick={(event) => {
+                    this.setState({ showLayoutModal: true, selectedLayout: layout });
                     event.stopPropagation();
-                    this.setState({ showLayoutModal: true, selectedLayout: layout })}
-                }
+                }}
+                // Required for accessibility
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                        this.setState({ showLayoutModal: true, selectedLayout: layout });
+                        event.preventDefault();
+                    }
+                }}
             />
         </Stack>
     )
@@ -188,6 +202,7 @@ export class Pages extends React.Component<PagesProps, PagesState> {
                                 key={page.key}
                                 className="nav-item-list-button"
                                 onRenderText={() => this.renderPageContent(page)}
+                                onClick={async () => await this.router.navigateTo(page.permalink)}
                             />
                         )}
                     </div>
@@ -218,6 +233,7 @@ export class Pages extends React.Component<PagesProps, PagesState> {
                                 key={layout.key}
                                 className="nav-item-list-button"
                                 onRenderText={() => this.renderPageLayoutContent(layout)}
+                                onClick={async () => this.viewManager.setHost({ name: 'layout-host', params: { layoutKey: layout.key } })}
                             />
                         )}
                     </div>

--- a/src/admin/popups/popups.tsx
+++ b/src/admin/popups/popups.tsx
@@ -77,10 +77,18 @@ export class Popups extends React.Component<PopupsProps, PopupsState> {
                 title="Edit"
                 style={iconStyles}
                 className="nav-item-inner"
+                tabIndex={0}
                 onClick={(event) => {
+                    this.setState({ showPopupDetailsModal: true, selectedPopup: popup });
                     event.stopPropagation();
-                    this.setState({ showPopupDetailsModal: true, selectedPopup: popup })}
-                }
+                }}
+                // Required for accessibility
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                        this.setState({ showPopupDetailsModal: true, selectedPopup: popup });
+                        event.preventDefault();
+                    }
+                }}
             />
         </Stack>
     )

--- a/src/admin/urls/urls.tsx
+++ b/src/admin/urls/urls.tsx
@@ -77,10 +77,18 @@ export class Urls extends React.Component<UrlsProps, UrlsState> {
                 title="Edit"
                 style={iconStyles}
                 className="nav-item-inner"
+                tabIndex={0}
                 onClick={(event) => {
+                    this.setState({ showUrlDetailsModal: true, selectedUrl: url });
                     event.stopPropagation();
-                    this.setState({ showUrlDetailsModal: true, selectedUrl: url })}
-                }
+                }}
+                // Required for accessibility
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                        this.setState({ showUrlDetailsModal: true, selectedUrl: url });
+                        event.preventDefault();
+                    }
+                }}
             />
         </Stack>
     )

--- a/src/themes/designer/styles/admin.scss
+++ b/src/themes/designer/styles/admin.scss
@@ -95,6 +95,10 @@
 
     .nav-item-inner {
         opacity: 0;
+
+        &:focus {
+            opacity: 1;
+        }
     }
 
     &:hover {


### PR DESCRIPTION
Problem:
Pages, layouts, URLs, popups and custom widgets were not keyboard interactable which was an important accessibility issue.

Fix:
Added keyboard tab/enter key presses support for listed items.