### PR TITLE
Added a fix for incorrect validation

### DIFF
--- a/src/admin/pages/pageDetailsModal.tsx
+++ b/src/admin/pages/pageDetailsModal.tsx
@@ -134,12 +134,13 @@ export class PageDetailsModal extends React.Component<PageDetailsModalProps, Pag
     }
 
     savePage = async (): Promise<void> => {
-        if (this.state.page.permalink === '/new-page') { 
-            const permalinkError = await this.validatePermalink(this.state.page.permalink);
-            if (permalinkError) {
-                this.setState({ errors: { permalink: permalinkError } });
-                return;
-            }
+        // TODO: find a root cause of an ability to click Save button when name is empty or permalink is not unique
+        const permalinkError = await this.validatePermalink(this.state.page.permalink);
+        const titleError = validateField(REQUIRED, this.state.page.title);
+
+        if (permalinkError || titleError) {
+            this.setState({ errors: { permalink: permalinkError, title: titleError } });
+            return;
         }
 
         if (this.props.page && !this.state.copyPage) {
@@ -206,6 +207,7 @@ export class PageDetailsModal extends React.Component<PageDetailsModalProps, Pag
                                 required
                             />}
                         ariaLabel="Name"
+                        placeholder="Enter the page name"
                         value={this.state.page.title}
                         onChange={(event, newValue) => this.onInputChange('title', newValue, REQUIRED)}
                         errorMessage={this.state.errors['title'] ?? ''}
@@ -220,6 +222,7 @@ export class PageDetailsModal extends React.Component<PageDetailsModalProps, Pag
                             />
                         }
                         ariaLabel="Permalink path"
+                        placeholder="Enter the permalink path"
                         value={this.state.page.permalink}
                         onChange={(event, newValue) => this.onInputChange('permalink', newValue)}
                         errorMessage={this.state.errors['permalink'] ?? ''}

--- a/src/admin/pages/pageLayoutDetailsModal.tsx
+++ b/src/admin/pages/pageLayoutDetailsModal.tsx
@@ -106,13 +106,13 @@ export class PageLayoutDetailsModal extends React.Component<PageLayoutModalProps
     }
 
     saveLayout = async (): Promise<void> => {
-        if (this.state.layout.permalinkTemplate === '/new-layout') { 
-            const permalinkError = await this.validatePermalink(this.state.layout.permalinkTemplate);
-            if (permalinkError) {
-                this.setState({ errors: { permalinkTemplate: permalinkError } });
-            
-                return;
-            }
+        // TODO: find a root cause of an ability to click Save button when name is empty or permalink is not unique
+        const permalinkError = await this.validatePermalink(this.state.layout.permalinkTemplate);
+        const titleError = validateField(REQUIRED, this.state.layout.title);
+ 
+        if (permalinkError || titleError) {
+            this.setState({ errors: { permalinkTemplate: permalinkError, title: titleError } });
+            return;
         }
 
         if (this.props.layout && !this.state.copyLayout) {
@@ -173,6 +173,7 @@ export class PageLayoutDetailsModal extends React.Component<PageLayoutModalProps
                     }
                     <TextField
                         label="Title"
+                        placeholder="Enter the layout name"
                         value={this.state.layout.title}
                         onChange={(event, newValue) => this.onInputChange('title', newValue, REQUIRED)}
                         errorMessage={this.state.errors['title'] ?? ''}
@@ -188,6 +189,7 @@ export class PageLayoutDetailsModal extends React.Component<PageLayoutModalProps
                             />
                         }
                         ariaLabel="Permalink path template"
+                        placeholder="Enter the permalink path template"
                         value={this.state.layout.permalinkTemplate}
                         onChange={(event, newValue) => this.onInputChange('permalinkTemplate', newValue)}
                         errorMessage={this.state.errors['permalinkTemplate'] ?? ''}

--- a/src/admin/utils/validator.ts
+++ b/src/admin/utils/validator.ts
@@ -16,14 +16,15 @@ export const validateField = (validationType: string, value: string, customValid
 
     const absoluteUrlRegex = /^(?:https?:\/\/)?(?:[\w-]+\.)*[\w.-]+\.[a-zA-Z]{2,}(?:\/[\w-.~:/?#[\]@!$&'()*+,;=%]*)?$/;
     const relativeUrlRegex = /^(?:\/|#)[\w-.~:/?#[\]@!$&'()*+,;=%]*$/;
+    const isNotEmpty = value.length > 0 && value.trim().length > 0;
 
     switch (validationType) {
         case REQUIRED:
-            isValid = value.length > 0;
+            isValid = isNotEmpty;
             errorMessage = isValid ? "" : REQUIRED_MESSAGE;
             break;
         case UNIQUE_REQUIRED:
-            isValid = value.length > 0 && customValidation;
+            isValid = isNotEmpty && customValidation;
             errorMessage = isValid ? "" : UNIQUE_REQUIRED_MESSAGE;
             break;
         case URL:
@@ -31,7 +32,7 @@ export const validateField = (validationType: string, value: string, customValid
             errorMessage = isValid ? "" : URL_MESSAGE;
             break;
         case URL_REQUIRED:
-            isValid = value.length > 0 && (absoluteUrlRegex.test(value) || relativeUrlRegex.test(value));
+            isValid = isNotEmpty && (absoluteUrlRegex.test(value) || relativeUrlRegex.test(value));
             errorMessage = isValid ? "" : URL_REQUIRED_MESSAGE;
             break;
     }


### PR DESCRIPTION
Problem:
There is a bug that the validation is not triggered correctly and there is an option to save a page with empty name and non-unique permalink.

Solution:
To proceed with the release implemented a temporary fix that the validation for these two fields are run again on Save button click.
Additionally removed an option to save a required field with a value which contains spaces only.