### PR TITLE
Fixed integration user errors

### DIFF
--- a/.github/workflows/mainCI.yml
+++ b/.github/workflows/mainCI.yml
@@ -40,7 +40,7 @@ jobs:
           input-urls: http://localhost:12345/profile http://localhost:12345/500 http://localhost:12345/404
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: accessibility-reports
           path: ${{ github.workspace }}/_accessibility-reports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run tests
         run: npx playwright test tests/ --workers 1
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: playwright-report

--- a/src/components/users/profile/ko/runtime/profile.ts
+++ b/src/components/users/profile/ko/runtime/profile.ts
@@ -69,7 +69,7 @@ export class Profile {
         await this.usersService.ensureSignedIn();
 
         const model: User = await this.usersService.getCurrentUser();
-        this.isBasicAccount(model.isBasicAccount);
+        this.isBasicAccount(model?.isBasicAccount);
         this.setUser(model);
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -340,3 +340,8 @@ export const overrideToastSessionKeyPrefix = "MS_APIM_CW_override_toast_dismisse
  */
 export const mobileBreakpoint = 768;
 export const smallMobileBreakpoint = 400;
+
+/**
+ * Key of the default admin user
+ */
+export const integrationUserId = '/users/integration';

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -23,7 +23,7 @@ export class User {
         this.note = contract.properties.note;
         this.groups = contract.properties.groups;
         this.identities = contract.properties.identities;
-        this.isBasicAccount = this.identities[0]?.provider === "Basic";
+        this.isBasicAccount = this.identities?.[0]?.provider === "Basic";
     }
 }
 

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -180,6 +180,10 @@ export class ProductService {
         if (!userId) {
             throw new Error(`Parameter "userId" not specified.`);
         }
+        
+        if (userId === Constants.integrationUserId) {
+            return new Page();
+        }
 
         const skip = searchRequest && searchRequest.skip || 0;
         const take = searchRequest && searchRequest.take || Constants.defaultPageSize;

--- a/src/services/usersService.ts
+++ b/src/services/usersService.ts
@@ -181,7 +181,7 @@ export class UsersService {
         try {
             const userId = await this.getCurrentUserId();
 
-            if (!userId) {
+            if (!userId || userId === Constants.integrationUserId) {
                 return null;
             }
 


### PR DESCRIPTION
Problem:
When navigating to the Profile page in admin mode, the errors were thrown as there is impossible to retrieve some information for integration user.

Solution:
Added checks if the user is integration to prevent unnecessary requests sending and error throwing.