### PR TITLE
Fixed custom widgets editor configuration view

### DIFF
--- a/src/components/custom-widget/ko/customWidgetEditorViewModel.ts
+++ b/src/components/custom-widget/ko/customWidgetEditorViewModel.ts
@@ -24,7 +24,7 @@ export class CustomWidgetEditorViewModel implements WidgetEditor<CustomWidgetMod
     public readonly src: ko.Observable<string>;
     public readonly instanceId: ko.Observable<string>;
     public readonly iframeAllows: string = iframeAllows;
-    public readonly iframeSandboxAllows: string = iframeSandboxAllows;
+    public readonly iframeSandboxAllows: string = CustomWidgetEditorViewModel.buildSandboxParams();
 
     constructor(
         private readonly viewManager: ViewManager,
@@ -67,6 +67,10 @@ export class CustomWidgetEditorViewModel implements WidgetEditor<CustomWidgetMod
         const environment = await this.settingsProvider.getSetting<string>("environment") as Environment;
         const widgetSource = await buildWidgetSource(this.blobStorage, this.model, environment, "editor.html");
         this.src(widgetSource.src);
+    }
+
+    private static buildSandboxParams() {
+        return iframeSandboxAllows + " allow-same-origin";
     }
 
     private updateResponsiveObservables(): void {


### PR DESCRIPTION
Custom widgets configuration view failing with error for cross origin. Added allow-same-origin to iframe sandbox parameters to fix the issue.