### PR TITLE
Fixed nonImageDetailModal to pass schema validation on saving of linked image

### DIFF
--- a/src/admin/media/nonImageDetailsModal.tsx
+++ b/src/admin/media/nonImageDetailsModal.tsx
@@ -8,6 +8,7 @@ import { DefaultButton, Modal, PrimaryButton, Stack, Text, TextField } from '@fl
 import { CopyableTextField } from '../utils/components/copyableTextField';
 import { REQUIRED, UNIQUE_REQUIRED, URL_REQUIRED, validateField } from '../utils/validator';
 import { reservedPermalinks } from '../../constants';
+import { MimeTypes } from '@paperbits/common';
 
 interface NonImageDetailsModalState {
     mediaItem: MediaContract,
@@ -78,11 +79,12 @@ export class NonImageDetailsModal extends React.Component<NonImageDetailsModalPr
                 mediaItem: {
                     ...this.state.mediaItem,
                     fileName: newName,
-                    permalink: '/content/' + newName
+                    permalink: '/content/' + newName,
+                    mimeType: MimeTypes.imageSvg
                 }
             })
         }
-    } 
+    }
 
     validatePermalink = async (permalink: string): Promise<string> => {
         if (permalink === this.props.mediaItem?.permalink) return '';
@@ -107,7 +109,7 @@ export class NonImageDetailsModal extends React.Component<NonImageDetailsModalPr
         this.eventManager.dispatchEvent('onSaveChanges');
         this.props.onDismiss();
     }
-    
+
     render(): JSX.Element {
         return <>
             <Modal


### PR DESCRIPTION
Link image in non media modal failing with invalid schema, because of missing `mediaType`