### PR TITLE
Fixed tabs styles and editor alignments

### DIFF
--- a/src/themes/designer/styles/forms.scss
+++ b/src/themes/designer/styles/forms.scss
@@ -239,6 +239,10 @@ details {
     padding-left: 20px;
     margin: 10px 0;
 
+    * {
+        position: relative;
+    }
+
     &[open]:before {
         content: "";
         left: 7px;

--- a/src/themes/website/styles/widgets/tabs.scss
+++ b/src/themes/website/styles/widgets/tabs.scss
@@ -6,6 +6,10 @@
 
     .tab-navs {
         display: flex;
+
+        .nav-link-active {
+            font-weight: bold;
+        }
     }
 
     .tab-content {


### PR DESCRIPTION
Problem:
Tabs widget styles were not indicating which tab is selected.
Additionally after latest styles fix alignments inside styling editor were off.

Solution:
Made selected tab bold.
Fixed alignments.