### PR TITLE
Update package.json engines to require Node pre v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "azure"
     ],
     "engines": {
-        "node": ">=14.18.2"
+        "node": ">=14.18.2 <20"
     },
     "scripts": {
         "start": "webpack-dev-server --open --config webpack.develop.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "azure"
     ],
     "engines": {
-        "node": ">=14.18.2 <20"
+        "node": ">=14.18.2 <21"
     },
     "scripts": {
         "start": "webpack-dev-server --open --config webpack.develop.js",


### PR DESCRIPTION
Since Node.js v21 `global.navigator` is an immutable property and this code in paperbits core is making it impossible to publish:
https://github.com/paperbits/paperbits-core/blob/master/src/publishing/knockoutHtmlPagePublisherPlugin.ts#L29 

![image](https://github.com/user-attachments/assets/d1d6e25b-1381-4e0d-8de3-f5ce89182675)
