### PR TITLE
Fixed admin panels not being hidden on preview mode toggle

### DIFF
--- a/src/admin/rightPanel.tsx
+++ b/src/admin/rightPanel.tsx
@@ -99,6 +99,7 @@ export class RightPanel extends React.Component<{}, RightPanelState> {
         this.eventManager.addEventListener('onDataChange', this.onDataChange.bind(this));
         window.addEventListener('resize', this.checkScreenSize.bind(this));
         this.router.addRouteChangeListener(() => this.getPageName());
+        document.addEventListener('keydown', this.onModeChange.bind(this));
         this.getPageName();
         this.checkScreenSize();
         this.getRoles();
@@ -108,6 +109,27 @@ export class RightPanel extends React.Component<{}, RightPanelState> {
         this.eventManager.removeEventListener('onDataChange', this.onDataChange.bind(this));
         window.removeEventListener('resize', this.checkScreenSize.bind(this));        
         this.router.removeRouteChangeListener(() => this.getPageName());
+        document.removeEventListener('keydown', this.onModeChange.bind(this));
+    }
+
+    hideLeftPanel = () => {
+        document.getElementById('admin-left-panel').classList.add('hidden');
+        document.getElementById('main-content-wrapper').classList.add('is-focused');
+    }
+
+    showLeftPanel = () => {
+        document.getElementById('admin-left-panel').classList.remove('hidden');
+        document.getElementById('main-content-wrapper').classList.remove('is-focused');
+    }
+
+    onModeChange = () => {
+        if (this.viewManager.mode === 'preview') {
+            !this.state.isFocusedState && this.hideLeftPanel();
+            document.getElementById('admin-right-panel').classList.add('hidden');
+        } else {
+            !this.state.isFocusedState && this.showLeftPanel();
+            document.getElementById('admin-right-panel').classList.remove('hidden');
+        }
     }
 
     setPageName = () => {

--- a/src/themes/designer/styles/admin.scss
+++ b/src/themes/designer/styles/admin.scss
@@ -184,6 +184,10 @@
             height: auto;
         }
     }
+
+    &.hidden {
+        display: none;
+    }
 }
 
 .top-panel {


### PR DESCRIPTION
Problem:
There is a preview mode which can be toggled by pressing Ctrl+F10. The new redesigned admin panels were not hiding on this preview mode enabling.

Solution:
Added a listener for keyboard presses and admin panels visibility toggle when the mode is changing.