### PR TITLE
FUI - Fixed No auth flow error

### DIFF
--- a/src/components/operations/operation-details/react/runtime/operation-console/ConsoleAuthorization.tsx
+++ b/src/components/operations/operation-details/react/runtime/operation-console/ConsoleAuthorization.tsx
@@ -34,7 +34,7 @@ type ConsoleAuthorizationProps = {
     isGqlConsole?: boolean;
 }
 
-const noAuthFlow = "no-auth";
+export const noAuthFlow = "no-auth";
 
 export const ConsoleAuthorization = ({
     api,

--- a/src/components/operations/operation-details/react/runtime/operation-console/consoleUtils.tsx
+++ b/src/components/operations/operation-details/react/runtime/operation-console/consoleUtils.tsx
@@ -17,6 +17,7 @@ import { Utils } from "../../../../../../utils";
 import { OAuth2AuthenticationSettings } from "../../../../../../contracts/authenticationSettings";
 import { GrantTypes, oauthSessionKey } from "../../../../../../constants";
 import { SearchQuery } from "../../../../../../contracts/searchQuery";
+import { noAuthFlow } from "./ConsoleAuthorization";
 
 interface SubscriptionOption {
     name: string;
@@ -235,7 +236,7 @@ export const onGrantTypeChange = async (
 ): Promise<ConsoleHeader[]> => {
     await clearStoredCredentials(sessionManager);
 
-    if (!grantType || grantType === GrantTypes.password) {
+    if (!grantType || grantType === GrantTypes.password || grantType === noAuthFlow) {
         const authHeader = headers?.find(header => header.name() === KnownHttpHeaders.Authorization);
         if (authHeader) {
             const newHeaders = headers.filter(header => header.id !== authHeader.id);


### PR DESCRIPTION
Problem:
There was an error when No auth authorization flow was selected in the Operation console.

Solution:
The value of "no-auth" was not supported in onGrantTypeChange function. Fixed it.