### PR TITLE
Repair item 27777463: Checking for messages only from OAuth2 popup

### DIFF
--- a/src/services/oauthService.ts
+++ b/src/services/oauthService.ts
@@ -329,6 +329,9 @@ export class OAuthService {
 
                 const receiveMessage = async (event: MessageEvent<any>) => {
                     try {
+                        if (!popup || event.source !== popup) {
+                            return; // Ignore messages not from our popup
+                        }
                         const result = await listener(event);
                         resolve(result);
                     }


### PR DESCRIPTION
Developer portal test console does not work with browser extensions https://github.com/Azure/api-management-developer-portal/issues/2334 . Certain browser extensions are sending messages via window.postMessage during the time we open an authentication popup in developer console. Added checking for event's origin to match our popup window.