### PR TITLE
Added support for multi-tenant Entra ID apps.

### DIFF
--- a/src/components/users/signin-social/react/runtime/SignInAadRuntime.tsx
+++ b/src/components/users/signin-social/react/runtime/SignInAadRuntime.tsx
@@ -25,7 +25,7 @@ const SignInAadRuntimeFC = ({ label, signIn, tenants, classNames }: SignInAadRun
     return (
         <div className="flex flex-wrap">
             {tenants.map(tenant => (
-            <BtnSpinner onClick={()=>signIn(tenant)} className={classNames}>
+            <BtnSpinner key={tenant} onClick={()=>signIn(tenant)} className={classNames}>
                 <i className="icon-emb icon-svg-entraId"></i>
                 {tenants.length > 1 ? `${label} (${tenant.replace('.onmicrosoft.com', '')})`: label }
             </BtnSpinner>))}

--- a/src/components/users/signin-social/react/runtime/SignInAadRuntime.tsx
+++ b/src/components/users/signin-social/react/runtime/SignInAadRuntime.tsx
@@ -13,19 +13,23 @@ import { BtnSpinner } from "../../../../utils/react/BtnSpinner";
 
 type SignInAadRuntimeProps = {
     label: string
+    tenants: string[],
     replyUrl: string,
     classNames: string
 }
 type SignInAadRuntimeFCProps = SignInAadRuntimeProps & {
-    signIn: () => Promise<void>
+    signIn: (selectedTenant: string) => Promise<void>
 };
 
-const SignInAadRuntimeFC = ({ label, signIn, classNames }: SignInAadRuntimeFCProps) => {
+const SignInAadRuntimeFC = ({ label, signIn, tenants, classNames }: SignInAadRuntimeFCProps) => {
     return (
-        <BtnSpinner onClick={signIn} className={classNames}>
-            <i className="icon-emb icon-svg-entraId"></i>
-            {label}
-        </BtnSpinner>
+        <div className="flex flex-wrap">
+            {tenants.map(tenant => (
+            <BtnSpinner onClick={()=>signIn(tenant)} className={classNames}>
+                <i className="icon-emb icon-svg-entraId"></i>
+                {tenants.length > 1 ? `${label} (${tenant.replace('.onmicrosoft.com', '')})`: label }
+            </BtnSpinner>))}
+        </div>
     );
 };
 
@@ -48,23 +52,24 @@ export class SignInAadRuntime extends React.Component<SignInAadRuntimeProps> {
     private selectedService: IAadService;
     private aadConfig: AadClientConfig;
 
-    public async signIn(): Promise<void> {
+    public async signIn(selectedTenant: string): Promise<void> {
         dispatchErrors(this.eventManager, ErrorSources.signInOAuth, []);
         this.logger.trackEvent(eventTypes.aadLogin, { message: "Initiating AAD login" });
 
         try {
             this.aadConfig  = await this.settingsProvider.getSetting<AadClientConfig>(SettingNames.aadClientConfig);
 
-            if (this.aadConfig ) {
-                if (this.aadConfig .clientLibrary === AadClientLibrary.v2) {
+            if (this.aadConfig) {
+                if (this.aadConfig.clientLibrary === AadClientLibrary.v2) {
                     this.selectedService = this.aadServiceV2;
                 }
                 else {
                     this.selectedService = this.aadService;
                 }
 
-                await this.selectedService.signInWithAad(this.aadConfig .clientId, this.aadConfig .authority, this.aadConfig .signinTenant || defaultAadTenantName, this.props.replyUrl);
-            } else {
+                await this.selectedService.signInWithAad(this.aadConfig.clientId, this.aadConfig.authority, selectedTenant, this.props.replyUrl);
+            } 
+            else {
                 this.logger.trackEvent(eventTypes.aadLogin, { message: "AAD client config is not set" });
             }
         } catch (error) {

--- a/src/components/users/signin-social/signinSocialViewModelBinder.ts
+++ b/src/components/users/signin-social/signinSocialViewModelBinder.ts
@@ -53,10 +53,13 @@ export class SigninSocialViewModelBinder implements ViewModelBinder<SigninSocial
         const termsOfService = await this.getTermsOfService();
         const termsOfUse = (termsOfService.text && termsOfService.enabled) ? termsOfService.text : undefined;
 
+        const tenants = aadIdentityProvider.allowedTenants || [];
+        
         if (aadIdentityProvider) {
             state.aadConfig = {
                 classNames: classNames,
                 label: model.aadLabel,
+                tenants: tenants,
                 replyUrl: model.aadReplyUrl || undefined,
                 termsOfUse: aadB2CIdentityProvider ? undefined : termsOfUse // display terms of use only once if both configs are present
             };

--- a/src/contracts/aadB2CClientConfig.ts
+++ b/src/contracts/aadB2CClientConfig.ts
@@ -1,6 +1,6 @@
 import { AadClientConfig } from "./aadClientConfig";
 
-export interface AadB2CClientConfig extends AadClientConfig{
+export interface AadB2CClientConfig extends AadClientConfig {
     /**
      * Sign-in policy name. Only applies to AAD B2C identity provider.
      */

--- a/src/contracts/aadClientConfig.ts
+++ b/src/contracts/aadClientConfig.ts
@@ -18,6 +18,11 @@ export interface AadClientConfig {
     signinTenant: string;
 
     /**
+     * The list of allowed tenants for multi-tenant applications.
+     */
+    allowedTenants?: string[];
+
+    /**
      * The client library to be used in the developer portal
      */
     clientLibrary: AadClientLibrary;

--- a/src/publishing/aadConfigPublisher.ts
+++ b/src/publishing/aadConfigPublisher.ts
@@ -25,6 +25,7 @@ export class AadConfigPublisher implements IPublisher {
                 clientId: aadIdentityProvider.clientId,
                 authority: aadIdentityProvider.authority,
                 signinTenant: aadIdentityProvider.signinTenant,
+                allowedTenants: aadIdentityProvider.allowedTenants,
                 clientLibrary: aadIdentityProvider.clientLibrary
             };
 

--- a/src/services/runtimeConfigurator.ts
+++ b/src/services/runtimeConfigurator.ts
@@ -36,6 +36,7 @@ export class RuntimeConfigurator {
                 clientId: aadIdentityProvider.clientId,
                 authority: aadIdentityProvider.authority,
                 signinTenant: aadIdentityProvider.signinTenant,
+                allowedTenants: aadIdentityProvider.allowedTenants,
                 clientLibrary: aadIdentityProvider.clientLibrary
             };
 


### PR DESCRIPTION
**Problem**: Currently, it's impossible to sign-in with multi-tenant Entra ID application because UI does not allow it.
**Solution**: When more than one tenant is specified in "Allowed tenants" section of Entra ID configuration, render a separate "Sign-in" button for each tenant.

<img width="480" height="362" alt="image" src="https://github.com/user-attachments/assets/967a7d8b-c257-4bba-a590-d3c495775af9" />
