### PR TITLE
Added doctype and encoding to the HTML widget template.

### DIFF
--- a/src/components/custom-html/ko/constants.ts
+++ b/src/components/custom-html/ko/constants.ts
@@ -1,8 +1,9 @@
 import { SizeStylePluginConfig } from "@paperbits/styles/plugins";
 
-export const htmlCodeInitial =
-`<html>
+export const htmlCodeInitial =`<!DOCTYPE html>
+<html>
 <head>
+    <meta charset="utf-8">
     <style>
         /* Custom styles */
         body {

--- a/src/components/custom-html/ko/customHtmlPublishViewModelBinder.spec.ts
+++ b/src/components/custom-html/ko/customHtmlPublishViewModelBinder.spec.ts
@@ -7,8 +7,10 @@ import { IBlobStorage } from "@paperbits/common/persistence";
 import { expect } from "chai";
 import { CustomHtmlModel } from "../customHtmlModel";
 
-const htmlCode = `<html>
+const htmlCode = `<!DOCTYPE html>
+<html>
 <head>
+    <meta charset="utf-8">
     <style>
         /* Custom styles */
         body {


### PR DESCRIPTION
**Problem**: The Custom HTML widget in its default document doesn't have doctype and encoding, which results into issues with unicode characters in published portals.

<img width="1908" height="379" alt="image" src="https://github.com/user-attachments/assets/ac339fde-615f-4588-b64a-2f689aaf429f" />
