### PR TITLE
Enhance scripts with additional parameters for tenant and service principal support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
             },
             "devDependencies": {
                 "@azure/identity": "^4.0.1",
-                "@azure/storage-blob": "12.16.0",
+                "@azure/storage-blob": "^12.16.0",
                 "@playwright/test": "1.40.1",
                 "@types/chai": "^4.3.6",
                 "@types/google-maps": "^3.2.3",
@@ -317,6 +317,7 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
             "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -935,6 +936,8 @@
         },
         "node_modules/@azure/storage-blob": {
             "version": "12.16.0",
+            "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.16.0.tgz",
+            "integrity": "sha512-jz33rUSUGUB65FgYrTRgRDjG6hdPHwfvHe+g/UrwVG8MsyLqSxg9TaW7Yuhjxu1v1OZ5xam2NU6+IpCN0xJO8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1276,6 +1279,7 @@
         "node_modules/@floating-ui/dom": {
             "version": "1.6.11",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@floating-ui/core": "^1.6.0",
                 "@floating-ui/utils": "^0.2.8"
@@ -1358,6 +1362,7 @@
         "node_modules/@fluentui/react": {
             "version": "8.121.2",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@fluentui/date-time-utilities": "^8.6.9",
                 "@fluentui/font-icons-mdl2": "^8.5.52",
@@ -3070,8 +3075,7 @@
         "node_modules/@iarna/toml": {
             "version": "2.2.5",
             "license": "ISC",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/@inquirer/external-editor": {
             "version": "1.0.2",
@@ -4499,7 +4503,8 @@
         },
         "node_modules/@types/node": {
             "version": "20.6.2",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/node-fetch": {
             "version": "2.5.12",
@@ -4548,6 +4553,7 @@
         "node_modules/@types/react": {
             "version": "18.2.22",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -4679,6 +4685,7 @@
             "version": "5.62.0",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -5114,6 +5121,7 @@
         "node_modules/acorn": {
             "version": "8.10.0",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5168,6 +5176,7 @@
             "version": "6.12.6",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -5619,6 +5628,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001688",
                 "electron-to-chromium": "^1.5.73",
@@ -6301,6 +6311,7 @@
             "version": "8.17.1",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -6452,6 +6463,7 @@
             "version": "8.9.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -6555,6 +6567,7 @@
             "version": "8.2.0",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
@@ -6566,31 +6579,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/d-fischer"
-            }
-        },
-        "node_modules/cosmiconfig-toml-loader": {
-            "version": "1.0.0",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@iarna/toml": "^2.2.5"
-            }
-        },
-        "node_modules/cosmiconfig-typescript-loader": {
-            "version": "4.1.1",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=12",
-                "npm": ">=6"
-            },
-            "peerDependencies": {
-                "@types/node": "*",
-                "cosmiconfig": ">=7",
-                "ts-node": ">=10",
-                "typescript": ">=3"
             }
         },
         "node_modules/create-require": {
@@ -7003,6 +6991,7 @@
         "node_modules/d3-selection": {
             "version": "3.0.0",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -7673,6 +7662,7 @@
             "version": "8.45.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.4.0",
@@ -8607,6 +8597,7 @@
         "node_modules/graphql": {
             "version": "15.5.0",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 10.x"
             }
@@ -9463,7 +9454,8 @@
         },
         "node_modules/inversify": {
             "version": "5.1.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/inversify-react": {
             "version": "1.1.0",
@@ -10222,7 +10214,8 @@
         },
         "node_modules/knockout": {
             "version": "3.5.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/knockout-mapping": {
             "version": "2.6.0",
@@ -11338,6 +11331,7 @@
             "version": "8.9.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -11503,7 +11497,8 @@
         },
         "node_modules/monaco-editor": {
             "version": "0.29.1",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/mri": {
             "version": "1.2.0",
@@ -12323,6 +12318,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
@@ -12721,6 +12717,7 @@
         "node_modules/react": {
             "version": "18.2.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -12741,6 +12738,7 @@
         "node_modules/react-dom": {
             "version": "18.2.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.0"
@@ -13330,6 +13328,7 @@
             "version": "1.67.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -13401,6 +13400,7 @@
         "node_modules/scheduler": {
             "version": "0.23.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             }
@@ -13619,6 +13619,7 @@
         "node_modules/servie": {
             "version": "4.3.3",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@servie/events": "^1.0.0",
                 "byte-length": "^1.0.2",
@@ -14300,6 +14301,7 @@
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -14348,7 +14350,8 @@
         },
         "node_modules/tslib": {
             "version": "2.4.0",
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -14423,6 +14426,7 @@
         "node_modules/typescript": {
             "version": "4.9.5",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -14837,6 +14841,7 @@
             "version": "5.88.2",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^1.0.0",
@@ -14883,6 +14888,7 @@
             "version": "5.1.4",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",
@@ -14959,6 +14965,7 @@
             "version": "8.10.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -15066,6 +15073,7 @@
             "version": "8.9.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -15252,6 +15260,7 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
             "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     },
     "devDependencies": {
         "@azure/identity": "^4.0.1",
-        "@azure/storage-blob": "12.16.0",
+        "@azure/storage-blob": "^12.16.0",
         "@playwright/test": "1.40.1",
         "@types/chai": "^4.3.6",
         "@types/google-maps": "^3.2.3",

--- a/scripts.v3/capture.js
+++ b/scripts.v3/capture.js
@@ -15,6 +15,13 @@
  *   --serviceName < your service name >
  */
 
+/*
+* 12.18.2025 - Added the following arguments to align with migrate.js
+*    --TenantId "< optional (needed if tenant ID is different > \r
+*    --ServicePrincipal "< optional service principal or user name. > \r
+*    --ServicePrincipalSecret "< optional secret or password for service principal or az login for the destination. >\n`)
+*/
+
 const path = require("path");
 const { ImporterExporter } = require("./utils");
 
@@ -37,6 +44,21 @@ const yargs = require('yargs')
         type: 'string',
         description: 'API Management service name.',
         demandOption: true
+    })
+    .option('tenantId', {
+        type: 'string',
+        description: 'Azure tenant ID (optional, required if different from default).',
+        demandOption: false
+    })
+    .option('servicePrincipal', {
+        type: 'string',
+        description: 'service principal or user name.',
+        demandOption: false
+    })
+    .option('servicePrincipalSecret', {
+        type: 'string',
+        description: 'service principal secret.',
+        demandOption: false
     })
     .option('folder', {
         type: 'string',
@@ -79,9 +101,9 @@ async function capture() {
         yargs.subscriptionId,
         yargs.resourceGroupName,
         yargs.serviceName,
-        null,
-        null,
-        null,
+        yargs.tenantId,
+        yargs.servicePrincipal,
+        yargs.servicePrincipalSecret,
         absoluteFolder
     );
 

--- a/scripts.v3/cleanup.js
+++ b/scripts.v3/cleanup.js
@@ -18,6 +18,13 @@
  *    --destServiceName "< your service name >"
  */
 
+/*
+* 12.18.2025 - Added below arguments to align with migrate.js
+*    --TenantId "< optional (needed if tenant ID is different > \r
+*    --ServicePrincipal "< optional service principal or user name. > \r
+*    --ServicePrincipalSecret "< optional secret or password for service principal or az login for the destination. >\n`)
+*/
+
 const { ImporterExporter } = require("./utils");
 
 const yargs = require('yargs')
@@ -39,6 +46,21 @@ const yargs = require('yargs')
         type: 'string',
         description: 'API Management service name.',
     })
+    .option('tenantId', {
+        type: 'string',
+        description: 'Azure tenant ID (optional, required if different from your default tenant).',
+        demandOption: false
+    })
+    .option('servicePrincipal', {
+        type: 'string',
+        description: 'service principal or user name.',
+        demandOption: false
+    })
+    .option('servicePrincipalSecret', {
+        type: 'string',
+        description: 'service principal secret.',
+        demandOption: false
+    })
     .help()
     .argv;
 
@@ -46,7 +68,10 @@ async function cleanup() {
     const importerExporter = new ImporterExporter(
         yargs.subscriptionId,
         yargs.resourceGroupName,
-        yargs.serviceName
+        yargs.serviceName,
+        yargs.tenantId,
+        yargs.servicePrincipal,
+        yargs.servicePrincipalSecret
     );
 
     await importerExporter.cleanup();

--- a/scripts.v3/cleanupImportPublish.bat
+++ b/scripts.v3/cleanupImportPublish.bat
@@ -1,0 +1,21 @@
+@REM Make sure you're logged-in with `az login` command before running the script.
+@REM This 'cleanupImportPublish' wrapper script uses the shared 'cleanup', and generate' functionality to perform the cleanup, import and publish operation.
+
+@REM Delete the content (incl. pages, media files, configuration, etc.) of API Management developer portal.
+
+node ./cleanup ^
+--subscriptionId "< your destination subscription ID >" ^
+--resourceGroupName "< your destination resource group name >" ^
+--serviceName "< your destination service name >" ^
+--servicePrincipal "< your destination Service Principal >" ^
+--servicePrincipalSecret "< your destination Service Principal Secret >"
+
+@REM Generate content (incl. pages, media files, configuration, etc.) of API Management developer portal from ./dist/snapshot folder and publish it.
+
+node ./generate ^
+--subscriptionId "< your destination subscription ID >" ^
+--resourceGroupName "< your destination resource group name >" ^
+--serviceName "< your destination service name >" ^
+--servicePrincipal "< your destination Service Principal >" ^
+--servicePrincipalSecret "< your destination Service Principal Secret >" ^
+--publish "< your publish option >"

--- a/scripts.v3/export.bat
+++ b/scripts.v3/export.bat
@@ -1,0 +1,10 @@
+@REM Make sure you're logged-in with `az login` command before running the script.
+@REM Capture the content (incl. pages, media files, configuration, etc.) of API Management developer portal into ./dist/snapshot folder.
+@REM This 'export' wrapper script uses the shared 'capture' functionality to perform the export operation.
+
+node ./capture ^
+--subscriptionId "< your source subscription ID >" ^
+--resourceGroupName "< your source resource group name >" ^
+--serviceName "< your source service name >" ^
+--servicePrincipal "< your source Service Principal >" ^
+--servicePrincipalSecret "< your source Service Principal Secret >"

--- a/scripts.v3/generate.js
+++ b/scripts.v3/generate.js
@@ -16,6 +16,13 @@
  *   --publish true [false: default]
  */
 
+/*
+* 12.18.2025 - Added below arguments to align with migrate.js
+*    --TenantId "< optional (needed if tenant ID is different > \r
+*    --ServicePrincipal "< optional service principal or user name. > \r
+*    --ServicePrincipalSecret "< optional secret or password for service principal or az login for the destination. >\n`)
+*/
+
 const path = require("path");
 const { ImporterExporter } = require("./utils");
 
@@ -38,6 +45,21 @@ const yargs = require('yargs')
         type: 'string',
         description: 'API Management service name.',
         demandOption: true
+    })
+    .option('tenantId', {
+        type: 'string',
+        description: 'Azure tenant ID (optional, required if different from default).',
+        demandOption: false
+    })
+    .option('servicePrincipal', {
+        type: 'string',
+        description: 'service principal or user name.',
+        demandOption: false
+    })
+    .option('servicePrincipalSecret', {
+        type: 'string',
+        description: 'service principal secret.',
+        demandOption: false
     })
     .option('folder', {
         type: 'string',
@@ -68,9 +90,9 @@ async function generate() {
         yargs.subscriptionId,
         yargs.resourceGroupName,
         yargs.serviceName,
-        null,
-        null,
-        null,
+        yargs.tenantId,
+        yargs.servicePrincipal,
+        yargs.servicePrincipalSecret,
         absoluteFolder
     );
 

--- a/scripts.v3/migrate.bat
+++ b/scripts.v3/migrate.bat
@@ -2,9 +2,9 @@
 @REM Make sure you're logged-in with `az login` command before running the script.
 
 node ./migrate ^
---sourceSubscriptionId "< your subscription ID >" ^
---sourceResourceGroupName "< your resource group name >" ^
---sourceServiceName "< your service name >" ^
---destSubscriptionId "< your subscription ID >" ^
---destResourceGroupName "< your resource group name >" ^
---destServiceName "< your service name >"
+--sourceSubscriptionId "< your source subscription ID >" ^
+--sourceResourceGroupName "< your source resource group name >" ^
+--sourceServiceName "< your source service name >" ^
+--destSubscriptionId "< your destination subscription ID >" ^
+--destResourceGroupName "< your destination resource group name >" ^
+--destServiceName "< your destination service name >"


### PR DESCRIPTION
The default script (migrate.js) approach assumes direct connectivity – it logs into source and destination simultaneously and moves content. In strictly regulated or highly constrained enterprise environments, these might be isolated; direct source-to-destination transfers may be discouraged. An alternative is to export the portal content to a folder, then import from that into the next environment. This two-step process decouples the environments and allows for checkpoints or approvals in between. For example, you could run an Export from source (which uses the content API to pull down JSON and media), store those artifacts (perhaps check them into source control or attach to a pipeline artifact), then later run an Import into destination using those artifacts. Azure API Management’s content API supports this approach and cleanup.js, capture.js and generate.js leverages this but they unfortunately don't have service principals which can be configured which will be needed by the deployment pipeline to talk to APIM resource. The advantage is that you can version-control the portal content – treating it similarly to code – and implement promotion workflows with approval gates (e.g., a staging review before pushing to prod). This could also make backup possible if the customer needs to have one.

So I have updated these js files and provided 2 batch file for export and cleanupImportPublish.bat to facilitate these to be run for different environment which is decoupled