### PR TITLE
Fix crash rendering sign-in page when only AAD B2C is configured

### DIFF
--- a/src/components/users/signin-social/signinSocialViewModelBinder.ts
+++ b/src/components/users/signin-social/signinSocialViewModelBinder.ts
@@ -53,13 +53,11 @@ export class SigninSocialViewModelBinder implements ViewModelBinder<SigninSocial
         const termsOfService = await this.getTermsOfService();
         const termsOfUse = (termsOfService.text && termsOfService.enabled) ? termsOfService.text : undefined;
 
-        const tenants = aadIdentityProvider.allowedTenants || [];
-        
         if (aadIdentityProvider) {
             state.aadConfig = {
                 classNames: classNames,
                 label: model.aadLabel,
-                tenants: tenants,
+                tenants: aadIdentityProvider.allowedTenants || [],
                 replyUrl: model.aadReplyUrl || undefined,
                 termsOfUse: aadB2CIdentityProvider ? undefined : termsOfUse // display terms of use only once if both configs are present
             };


### PR DESCRIPTION
**Problem**: Publishing the portal (or rendering the Sign-in page) crashes with `TypeError: Cannot read properties of undefined (reading 'allowedTenants')` when only an AAD B2C identity provider is configured. `SigninSocialViewModelBinder.modelToState` reads `aadIdentityProvider.allowedTenants` before the `if (aadIdentityProvider)` guard, so it throws whenever no plain AAD provider is present.

**Solution**: Move the `tenants` lookup inside the existing `if (aadIdentityProvider)` block so it only runs when the provider exists. No behavior change when an AAD provider is configured.

Fixes #2874